### PR TITLE
fix Docker PHP timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Dockerfile for Dashticz
 # See http://nelkinda.com/blog/apache-php-in-docker/
 FROM php:apache
-USER root
+#Default value in case no build argument:
+ARG tz="Europe/Amsterdam" 
+RUN printf "[PHP]\ndate.timezone = $tz\n" > /usr/local/etc/php/conf.d/tzone.ini
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Closes #3 

You may force a timezone by setting the TZ environment variable.
this also can be done via Makefile.ini.
