### PR TITLE
fix RSS reader scrolling stops after coming back from standby mode

### DIFF
--- a/js/blocks.js
+++ b/js/blocks.js
@@ -114,9 +114,11 @@ function getBlock(cols, c, columndiv, standby) {
                     continue;
                 }
             }
-            $(columndiv).append('<div id="block_' + myBlockNumbering + '"</div>');
+            var blockIndex = 'block_'+myBlockNumbering;
+            blockIndex += standby ? '_sb':'';
+            $(columndiv).append('<div id="' + blockIndex + '"</div>');
             var myIndex = myBlockNumbering++;
-            var myblockselector = '#block_' + myIndex;
+            var myblockselector = '#'+blockIndex;
             
             switch (typeof(cols['blocks'][b])) {
                 case 'object':
@@ -293,7 +295,7 @@ function handleStringBlock(block, columndiv, width, c) {
         case 'news':
             if (typeof(getNews) !== 'function') $.ajax({url: 'js/news.js', async: false, dataType: "script"});
             $(columndiv).append('<div data-id="news" class="news"></div>');
-            getNews('news', settings['default_news_url']);
+            getNews(columndiv, 'news', settings['default_news_url']);
             return;
         case 'log':
             if (typeof(getLog) !== 'function') $.ajax({url: 'js/log.js', async: false, dataType: "script"});
@@ -352,7 +354,7 @@ function handleStringBlock(block, columndiv, width, c) {
             if (block.substring(0, 5) === 'news_') {
                 if (typeof(getNews) !== 'function') $.ajax({url: 'js/news.js', async: false, dataType: 'script'});
                 $(columndiv).append('<div class="' + block + '"></div>');
-                getNews(block, blocks[block]['feed']);
+                getNews(columndiv, block, blocks[block]['feed']);
                 return;
             }
             $(columndiv).append('<div data-id="' + block + '" class="mh transbg block_' + block + '"></div>');

--- a/js/news.js
+++ b/js/news.js
@@ -4,8 +4,8 @@ function setSrcRss(cur) {
 
 $.ajax({url: 'vendor/jquery.newsTicker.min.js', async: false, dataType: 'script'});
 
-function getNews(divToFill, newsfeed) {
-    if (typeof(settings['default_news_url']) !== 'undefined') {
+function getNews(columndiv, blockdef, newsfeed) {
+    if (typeof(newsfeed) !== 'undefined' && newsfeed!=='') {
         // Some RSS feed doesn't load trough crossorigin.me or vice versa
         //$.ajax('https://crossorigin.me/'+newsfeed, {
         $.ajax(_CORS_PATH + newsfeed, {
@@ -16,16 +16,16 @@ function getNews(divToFill, newsfeed) {
             success: function (data) {
 
                 var width = 12;
-                if (typeof(blocks[divToFill]) !== 'undefined' && typeof(blocks[divToFill]['width']) !== 'undefined') width = blocks[divToFill]['width'];
+                if (typeof(blocks[blockdef]) !== 'undefined' && typeof(blocks[blockdef]['width']) !== 'undefined') width = blocks[blockdef]['width'];
 
                 var maxheight = 0;
-                if (typeof(blocks[divToFill]) !== 'undefined' && typeof(blocks[divToFill]['maxheight']) !== 'undefined') maxheight = blocks[divToFill]['maxheight'];
+                if (typeof(blocks[blockdef]) !== 'undefined' && typeof(blocks[blockdef]['maxheight']) !== 'undefined') maxheight = blocks[blockdef]['maxheight'];
 
                 var maxcss = '';
                 if (maxheight > 0) maxcss = ' style="max-height:' + maxheight + 'px;overflow:hidden;"';
 
                 var html = '<div class="col-xs-' + width + ' hover transbg" ' + maxcss + '><div class="col-xs-2 col-icon"><em class="fas fa-newspaper"></em></div><div class="col-xs-10">';
-                html += '<div id="rss-styled_' + divToFill + '"><ul id="newsTicker">';
+                html += '<div id="rss-styled_' + blockdef + '"><ul id="newsTicker">';
 
                 $(data).find('item').each(function () { // or "item" or whatever suits your feed
                     var el = $(this);
@@ -34,7 +34,7 @@ function getNews(divToFill, newsfeed) {
                 });
 
                 html += '</div></div></div>';
-                $('div.' + divToFill).replaceWith('<div class="' + divToFill + '">' + html + '</div>');
+                $(columndiv).replaceWith('<div class="' + blockdef + '">' + html + '</div>');
 
                 if ($('#rssweb').length === 0) {
                     var htmlRss = '<div class="modal fade" id="rssweb" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">';
@@ -52,7 +52,7 @@ function getNews(divToFill, newsfeed) {
                     $('body').append(htmlRss);
                 }
 
-                newsWrapper = $('#rss-styled_' + divToFill).easyTicker({
+                newsWrapper = $('#rss-styled_' + blockdef).easyTicker({
                     direction: 'up',
                     easing: 'lineair',
                     speed: 'slow',
@@ -62,13 +62,14 @@ function getNews(divToFill, newsfeed) {
                 }).data('easyTicker');
 
                 var maxHeight = -1;
+                if (typeof(blocks[blockdef]) !== 'undefined' && typeof(blocks[blockdef]['maxheight']) !== 'undefined') maxHeight = blocks[blockdef]['maxheight'];
 
-                $('#rss-styled_' + divToFill + ' li').each(function () {
+                $('#rss-styled_' + blockdef + ' li').each(function () {
                     maxHeight = maxHeight > $(this).height() ? maxHeight : $(this).height();
                 });
 
                 if(maxHeight > 0) {
-                  $('#rss-styled_' + divToFill).parents('.transbg').height(maxHeight);
+                  $('#rss-styled_' + blockdef).parents('.transbg').height(maxHeight);
                 }
             },error: function(data){
 		infoMessage('<font color="red">News Error!</font>','RSS feed ' + data.statusText +'. Check rss url.', 10000);
@@ -76,7 +77,7 @@ function getNews(divToFill, newsfeed) {
         });
 
         setTimeout(function () {
-          getNews(divToFill, newsfeed);
+          getNews(columndiv, blockdef, newsfeed);
         }, (60000 * 5));
     }
 }


### PR DESCRIPTION
Bug: RSS reader scrolling stops after comming back from standby mode

Only in case a news block is used in a normal dashboard and in standby mode.

Closes #8 


