### PR TITLE
Sorting devices' data is now optional

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1905,10 +1905,6 @@ function getThermostatBlock(device, idx) {
     return [this.html, false];
 }
 
-//#################################################
-// EVOHOME > Start                                #
-//#################################################
-
 function getEvohomeZoneBlock(device, idx) {
 	var temp		= device.Temp;
     var setpoint	= device.SetPoint;
@@ -1925,7 +1921,7 @@ function getEvohomeZoneBlock(device, idx) {
 	var fa_status = (status == 'TemporaryOverride') ? 'fas fa-stopwatch' : 'far fa-calendar-alt';
 
 	var untilOrLastUpdate = (status == 'Auto' || status == 'TemporaryOverride') ? 'Until ' + moment(device['Until']).format('HH:mm') : moment(device['LastUpdate']).format(settings['timeformat']);
-
+	
     var html = '';
     html += '<div class="col-button1">';
     html += '	<div class="up">';
@@ -2210,10 +2206,6 @@ function switchEvoHotWater(idx, state, override) {
         }
     });
 }
-
-//#################################################
-// EVOHOME > End                                  #
-//#################################################
 
 function getDimmerBlock(device, idx, buttonimg) {
     var html = '';


### PR DESCRIPTION
**Updates:**

1. Until now, the code automatically calculated if any devices' time data was longer than others. It then used that device's time data, then matched all of the devices non-time data to that. This update allows users to choose to enable or disable that feature with a new block setting: `sortDevices: true/false`. The issue raised on the forum today. Refenced link below:
https://www.domoticz.com/forum/viewtopic.php?f=67&t=30398&start=60#p234266


2. SubType "Thermostat" has been added.