### PR TITLE
GroupBy, defined Popups and fixes

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -712,7 +712,12 @@ a.playlist {
 	font-size: 150%;
 }
 
-.graphbuttons {
+.graphbuttons .btn {
+	opacity: 0.5;
+}
+
+.graphbuttons .btn.active {
+	opacity: 1;
 }
 
 .graph {
@@ -1482,8 +1487,9 @@ fieldset[disabled] .btn-primary.active {
 }
 
 .btn-group .btn.active {
-	font-weight:700;
+	font-weight:700;	
 }
+
 .modal-login {
     max-height: 90%;
     max-width:90%;
@@ -1727,11 +1733,11 @@ canvas{
 }
 
 .chartjs-tooltip.left {
-	transform: translate(13%, -100%);
+	transform: translate(13%, 15%);
 }
 
 .chartjs-tooltip.right {
-    transform: translate(-110%, -100%)
+    transform: translate(-110%, 15%)
 }
 
 .chartjs-tooltip.left:before,


### PR DESCRIPTION
**Fixes:**
Graph header value fix for single devices with sub-devices (multidata). This now shows the current value (as before the last update).

**New:**
_GroupBy_
New graph block parameter added; “GroupBy”. This allows users to group their data by hour, day, week or month, where applicable ranges are used. The GroupBy param can be set on the graph block as follows:
```
blocks['group_by_solar'] = {    
    title: ‘Solar',
    devices: [1],
    graph: ['bar'],
    graphTypes: ['v'],
    groupBy: ‘week’,
    legend: true
}  
```
Alternatively, the param can be applied to custom data as follows:
```
blocks['group_by_solar'] = {    
    title: 'Grouped: Solar',
    devices: [1],
    graph: ['bar'],
    graphTypes: ['v'],
    custom : {
        "Day by Hour": {
            range: 'last',
            groupBy: 'hour',
            filter: '24 hours',
            data: {
                Solar: 'd.v_1'
            },
        },
        "Week by Day": {
            range: 'month',
            groupBy: 'day',
            filter: '7 days',
            data: {
                Solar: 'd.v_1',
            }
        },
        "Month by Week": {
            range: 'month',
            groupBy: 'week',
            data: {
                Solar: 'd.v_1',
            }
        },
        "Year by Month": {
            range: 'year',
            groupBy: 'month',
            data: {                
                Solar: 'd.v_1',
            }
        }
    },
    datasetColors: ['green'],
    legend: true
}  
```
The GroupBy function will either:
1.	The “sum” of all values together for that group
2.	Provide the “average” of all values for that group
It identifies what type of sensor it is to apply to appropriate calculation.
•	Counter, Rain – uses the “Add’ calculation
•	Temperature, Custom Sensor and Percentage – uses the “Average” calculation

_beginAtZero_
New graph block param added; “beginAtZero”. This forces the Y axis to begin at 0 (zero). 
```
blocks['kitchen_temp'] = {    
    title: 'Kitchen Temperature',
    devices: [6],
    beginAtZero: true,
    toolTipStyle: true,
    legend: true
}
```
_Defined Popups_
Popups can now be defined by adding a new block parameter, “popup”, to the block that popup is for. This allows the popup to use all the block parameters that a graph block does, allowing them to style the graph however they want. It also means the legend and tooltips can display custom names (instead of the key names).
For example, the user as an Energy meter block defined as follows:
```
blocks[258] = {
    title: 'Consumption',
    flash: 500,
    width: 4,
    popup: 'popup_consumption'
}
```
In this example, they have specified that the popup will use a defined graph called  'popup_consumption' instead of the default popup. This defined graph is then added to the config.js just like a normal graph:
```
blocks['popup_consumption'] = {
    title: 'Energy Consumption Popup',
    devices: [258],
    toolTipStyle: true,
    datasetColors: ['red', 'yellow'],
    graph: 'line',
    legend: {
        'v_258' : 'Usage',          
        'c_258' : 'Total'
    }
}
```
**Changes**
_Zoom_
The graph zoom control has been updated. There is no longer a requirement for config[‘graph_zoom’] to be set in the config.js. This can be removed. Instead, a new graph block parameter has been added; “zoom”.
If set, the new param accepts 4 values: “x”, “y”, “xy” or false. This allows the user to decide which graph they want to apply zoom controls to, but also, which orientation. 
•	x – allow zooming on the x axis (left to right)
•	y – allow zooming on the y axis (top to bottom)
•	xy – allow zooming in any direction
•	false – disable zooming, do not show zoom button

```
blocks['wind'] = {
    title: 'Wind',
    devices: [73],
    graph: 'line',
    zoom: 'xy',
    legend: {
        'di_73' : 'Direction',          
        'sp_73' : 'Speed',
        'gu_73' : 'Gust'
    }
}
```

