### PR TITLE
Add groupByDevice

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -1888,7 +1888,9 @@ canvas{
     padding: 0px 10px;
     border: solid 0.5px white;
     border-radius: 3px;
-    margin-right: 10px;
+	margin-right: 10px;
+	overflow: scroll;
+	max-height: 500px;
 }
 
 .graph-menu .device-list .device {


### PR DESCRIPTION
**Add:** 
New graph block parameter added, **_groupByDevice_**, allowing user to show the status of several devices in a single graph. Instead of the data being group by time intervals, it is grouped by the devices.

`groupByDevice: false` - disables the feature (default)
`groupByDevice: true` - enables the feature and display a vertical bar chart, grouped by device
`groupByDevice: 'vertical'` - is the same as true (above)
`groupByDevice: 'horizontal'` - enables the feature and display a horizontal bar chart, grouped by device

```
blocks['server_status'] = { 
    title: 'Server Status',
    devices: [17, 18, 189, 190, 192],
    groupByDevice: true,    
    beginAtZero: true
}
```

![image](https://user-images.githubusercontent.com/33834551/75613109-cbd4f100-5b21-11ea-90a6-e75bd276d4ab.png)

The feature works with device sensors such as counter, percentage and temperature.

With temperature sensors that have setpoints, it calculates whether the device is:

- Cold - blue
- At setpoint - orange
- Hot - red

The office and penthouse rooms are showing red, as the temperature is above the setpoint ...

![image](https://user-images.githubusercontent.com/33834551/75613119-ddb69400-5b21-11ea-9cf9-d407d7c72e50.png)

Same as above, but setting groupByDevice to 'horizontal' shows this ...

![image](https://user-images.githubusercontent.com/33834551/75613123-e73ffc00-5b21-11ea-8144-2d81b5214e04.png)

**Fix**:
Minor issue with the recently updated getYlabels function, where it was adding undefined as the 2nd y label. Now fixed.
