### PR TITLE
Stacked bar chart & coronavirus component

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -1733,15 +1733,20 @@ canvas{
 }
 
 .chartjs-tooltip.left {
-	transform: translate(13%, 15%);
+	transform: translate(13%, -30%);
 }
 
 .chartjs-tooltip.right {
-    transform: translate(-110%, 15%)
+    transform: translate(-110%, -30%);
+}
+
+.chartjs-tooltip.bottom {
+    transform: translate(-50%, -150%);
 }
 
 .chartjs-tooltip.left:before,
-.chartjs-tooltip.right:before {
+.chartjs-tooltip.right:before,
+.chartjs-tooltip.bottom:before {
     border: solid;
     border-color: #111 transparent;
     border-color: rgba(0, 0, 0, .8) transparent;
@@ -1751,13 +1756,21 @@ canvas{
 	top: 57%;
     position: absolute;
 }
+
 .chartjs-tooltip.left:before {
 	left: 0%;
     transform: rotate(90deg) translate(-100%, 100%);    
 }
+
 .chartjs-tooltip.right:before {
 	left: 100%;
     transform: rotate(270deg) translate(100%, 0%);    
+}
+
+.chartjs-tooltip.bottom:before {
+	left: 50%;
+    top: 100%;
+    transform: rotate(0deg) translate(-50%, 0%);
 }
 
 .chartjs-tooltip thead {
@@ -1928,6 +1941,58 @@ canvas{
 	background-color: white;
 }
 /* END: GRAPH-MENU MODAL */
+
+/* START: CORONAVIRUS */
+.coronavirus .graphheader {
+	height: 20px;
+}
+
+.coronavirus .graphtitle {
+	width: 90%;
+}
+
+.coronavirus .graphheader .fx {
+	font-size: 16px!important;
+	margin-left: 10px;
+}
+
+.coronavirus .graphheader img {
+	height: 20%;
+	margin-right: 5px;
+}
+
+.coronavirus.block_report {
+	font-size: 24px!important;
+	padding: 15px 5px!important;
+}
+
+.coronavirus.block_report .fx {
+	font-size: 150%!important;
+}
+
+.coronavirus.block_report .title {
+	font-size: 14px!important;
+	color: #ccc;
+}
+
+.coronavirus.block_report .title {
+	font-weight: 900;
+}
+
+.coronavirus.block_report .flag {
+	max-width: 100%;
+}
+
+.vertical-center {
+	display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}
+
+/* END: CORONAVIRUS */
+
 
 /* PLUGINS */
 .morris-hover{position:absolute;z-index:1000}.morris-hover.morris-default-style{border-radius:10px;padding:6px;color:#666;background:rgba(255,255,255,0.8);border:solid 2px rgba(230,230,230,0.8);font-family:sans-serif;font-size:12px;text-align:center}.morris-hover.morris-default-style .morris-hover-row-label{font-weight:bold;margin:0.25em 0}

--- a/js/components/coronavirus.js
+++ b/js/components/coronavirus.js
@@ -1,0 +1,210 @@
+/* eslint-disable no-prototype-builtins */
+/* global Dashticz moment settings config language time blocks graph Chart _TEMP_SYMBOL getWeekNumber*/
+var api = 'https://coronavirus-tracker-api.herokuapp.com/v2/';
+var flagUrl = 'https://raw.githubusercontent.com/clinkadink/country-flags/master/png100px/';
+var nf = Intl.NumberFormat();
+
+var DT_coronavirus = {
+  name: "coronavirus",
+  canHandle: function(block, key) {
+    return (
+      block &&
+      typeof key === "string" &&
+      key.substring(0, 12) === "coronavirus_"
+    );
+  },
+  run: function(me) {
+
+    if (isDefined(me.block.graph) && isDefined(me.block.countryCode)) {
+      me.primaryIdx = me.mountPoint.slice(1);
+      me.graphIdx = me.primaryIdx;
+      me.name = isDefined(me.block.title) ? me.block.title : me.name.toUpperCase();
+      $.extend(me.block, getBlockDefaults(false, true, me.block));
+      createDashGraph(me);
+    }
+
+    if (isDefined(me.block.report)) {
+      createReportBlock(me, true);
+    }
+  }
+};
+
+Dashticz.register(DT_coronavirus);
+
+function createDashGraph(me) {
+
+  var dataUrl = api + "locations?country_code=" + me.block.countryCode + "&province&timelines=1";
+  
+  $.getJSON(dataUrl, function(json) {
+
+    var stats = {};
+    stats.latestConfirmed = json.latest.confirmed;
+    stats.latestDeaths = json.latest.deaths;
+    stats.country = json.locations[0].country;
+    stats.population = json.locations[0].country_population;
+    stats.lastUpdated = moment(json.locations[0].last_updated).format("HH:mm, DD/MM/YYYY");
+    stats.ratio = '1:' + (stats.population/stats.latestConfirmed).toFixed(0);
+
+    var template = '<span><img src="{{flag}}.png" class="flag">{{country}}: <i class="fas fa-hospital fx" style="color:{{color}};">&nbsp;</i>{{confirmed}}&nbsp;'
+    template += '<i class="fas fa-skull-crossbones fx" style="color:{{color}};">&nbsp;</i>{{deaths}}&nbsp;'
+    template += '<i class="fas fa-users fx" style="color:{{color}};">&nbsp;</i>{{ratio}}';
+    var data = { 
+        flag: flagUrl + me.block.countryCode.toLowerCase(),
+        country: stats.country,
+        confirmed: nf.format(stats.latestConfirmed),
+        deaths: nf.format(stats.latestDeaths),
+        ratio: stats.ratio,
+        color: me.block.iconColour
+	  };
+
+    me.currentValue = Handlebars.compile(template)(data);
+
+    var confirmed = json.locations[0].timelines.confirmed.timeline;
+    var deaths = json.locations[0].timelines.deaths.timeline;
+    
+
+    var graphData = {
+      labels: [],
+      datasets: [
+        {
+          label: "Confirmed",
+          backgroundColor: me.block.datasetColors[0],
+          data: []
+        },
+        {
+          label: "Deaths",
+          backgroundColor: me.block.datasetColors[1],
+          data: []
+        }
+      ]
+    };
+
+    var startDate = isDefined(me.block.startDate)? me.block.startDate : '22/01/2020';
+
+    for (var key in confirmed) {
+      if(moment(key).isSameOrAfter(moment(startDate, 'DD/MM/YYYY'))){
+        graphData.labels.push(moment(key).format("YYYY-MM-DD"));
+        graphData.datasets[0].data.push(confirmed[key]);
+      }
+    }
+
+    for (var key in deaths) {   
+      if(moment(key).isSameOrAfter(moment(startDate, 'DD/MM/YYYY'))){  
+        graphData.datasets[1].data.push(deaths[key]);
+      }
+    }
+
+    var buttons = createButtons(me);
+    var html = createHeader(me, true, buttons);
+    var mountPoint = $(me.mountPoint + " > div");
+    mountPoint.addClass("block_coronavirus").addClass("block_graph");
+
+    var graphProperties = getDefaultGraphProperties(me);
+    graphProperties.data = graphData;
+    graphProperties.type = isDefined(me.block.graph) ? me.block.graph : "bar";
+    graphProperties.options.scales.xAxes[0].stacked = isDefined(me.block.stacked) ? me.block.stacked : true;
+    graphProperties.options.scales.yAxes[0].stacked = isDefined(me.block.stacked) ? me.block.stacked : true;
+    graphProperties.options.scales.yAxes[0].ticks = { 
+      beginAtZero: true,
+      fontColor: "white",
+      callback: function(value, index, values) {
+        return  nf.format((value/1000)) + 'K';
+      }
+    }
+
+    var graphwidth = $(me.mountPoint + " .block_coronavirus").width();
+    var setHeight = Math.min(
+      Math.round((graphwidth / window.innerWidth) * window.innerHeight - 25),
+      window.innerHeight - 50
+    );
+    setHeight = me.block.height ? me.block.height : setHeight;
+    $(me.mountPoint + " .block_coronavirus").css("height", setHeight);
+    mountPoint.html(html);
+
+    var chartctx = mountPoint.find("canvas")[0].getContext("2d");
+    new Chart(chartctx, graphProperties);
+  });
+}
+
+function createReportBlock(me, province){
+
+  var p = province? '&province' : '';
+  var dataUrl = isDefined(me.block.countryCode)? api + "locations?country_code=" + me.block.countryCode + p + "&timelines=1" : api + "latest";
+  var width = isDefined(me.block.width)? me.block.width : 3;
+
+  $.ajax({
+    url: dataUrl,
+    success: function(json) {
+
+      var template = "";
+      template = '<div class="col-lg-2 col-sm-3 vertical-center">';
+      template += '<i class="fas fa-{{icon}} fx"></i>';
+      template += "</div>";
+      template += '<div class="col-lg-6 col-sm-5 col-data">';
+      template += '<strong class="title">{{title}}</strong><br>';
+      template += '<span class="report">{{report}}</span><br>';
+      template += "</div>";
+      template += '<div class="col-lg-4 col-sm-4 vertical-center">';
+      template += '<img src="{{flag}}.png" class="flag">';
+      template += "</div>";
+
+      var report = me.block.report.toLowerCase();
+      var data = nf.format(json.latest[report]);
+      var icon = report === "confirmed" ? "hospital" : "skull-crossbones";
+
+      if (report === "ratio") {
+        var population = 7775000000;
+        if (isDefined(me.block.countryCode)) {
+          population = json.locations[0].country_population;
+        }
+        data = "1 : " + nf.format((population / json.latest.confirmed).toFixed(0));
+        icon = "users";
+      }
+
+      if (report === "doubling" && isDefined(me.block.countryCode)) {
+        var timeline = json.locations[0].timelines.confirmed.timeline;
+        var halfLatestConfirmed = json.latest.confirmed / 2;
+        var d = 0;
+        var doublingHours = 0;
+        reverseForIn(timeline, function(key) {
+          if (this[key] <= halfLatestConfirmed && doublingHours === 0) {
+            doublingHours = d * 24;
+          }
+          d++;
+        });
+        data = doublingHours + " hours";
+        icon = "angle-double-up";
+      }
+
+      var data = {
+        width: width,
+        icon: icon,
+        title: (isDefined(me.block.countryCode) ? me.block.countryCode.toUpperCase() : "Global") + ": " + me.block.report,
+        report: data,
+        flag: flagUrl + (isDefined(me.block.countryCode)? me.block.countryCode.toLowerCase() : "world")
+      };
+
+      var mountPoint = $(me.mountPoint + " > div");
+      mountPoint.addClass("block_report");
+      mountPoint.html(Handlebars.compile(template)(data));
+      
+    },
+    complete: function(data) {},
+    error: function(xhr, ajaxOptions, thrownError) {
+      if (xhr.status == 404) {
+        createReportBlock(me, false);
+      }
+    }
+  });
+  
+}
+
+function reverseForIn(obj, f) {
+  var arr = [];
+  for (var key in obj) {
+    arr.push(key);
+  }
+  for (var i=arr.length-1; i>=0; i--) {
+    f.call(obj, arr[i]);
+  }
+}

--- a/js/components/graph.js
+++ b/js/components/graph.js
@@ -114,6 +114,7 @@ function getBlockDefaults(devices, hasBlock, b) {
   block.reverseTime = hasBlock && isDefined(b.reverseTime) ? b.reverseTime : false;
   block.sortDevices = hasBlock && isDefined(b.sortDevices) ? b.sortDevices : false;
   block.spanGaps = hasBlock && isDefined(b.spanGaps) ? b.spanGaps : false;
+  block.stacked = hasBlock && isDefined(b.stacked) ? b.stacked : false;
   block.title = hasBlock && isDefined(b.title) ? b.title : false;
   block.toolTipStyle = hasBlock && isDefined(b.toolTipStyle) ? b.toolTipStyle : false;
   block.width = hasBlock && isDefined(b.width) ? b.width : 12;
@@ -1104,27 +1105,28 @@ function createButtons(graph, ranges, customRange) {
       month: btn.text !== false ? btn.text[2] : language.graph.last_month
     };
   
-    if (graph.block.zoom) {
-      buttons += '<button type="button" data-canvas="graphoutput_' + graph.graphIdx + '" id="resetZoom' + graph.graphIdx + '" ' + style + '" class="btn btn-default">';
-      buttons += '  <i class="fas fa-search-minus" style="font-size:14px;color:' + btn.icon + '"></i>';
-      buttons += "</button>";
-  
-      $(document).on("click", "#resetZoom" + graph.graphIdx, function() {
-        Chart.helpers.each(Chart.instances, function(instance) {
-          if (
-            instance.chart.canvas.id ===
-            $("#resetZoom" + graph.graphIdx).data("canvas")
-          ) {
-            instance.chart.resetZoom();
-          }
-        });
-      });
-    }
     ranges.forEach(function(item, i) {
       var btnText = customRange ? item : btnTextList[item];
       buttons += '<button type="button" ' + style + '" class="btn btn-default';
       if (graph.range === item) buttons += " active";
       buttons += '" onclick="updateGraphs(\'' + graph.blockId + "', [" + graph.block.devices + "],'" + item + "','" + graph.popup + '\');"><i class="' + btnIcons[i] + '" style="font-size:14px;color:' + btn.icon + '">&nbsp;</i>&nbsp;' + btnText + "</button> ";
+    });
+  }
+
+  if (graph.block.zoom) {
+    buttons += '<button type="button" data-canvas="graphoutput_' + graph.graphIdx + '" id="resetZoom' + graph.graphIdx + '" ' + style + '" class="btn btn-default">';
+    buttons += '  <i class="fas fa-search-minus" style="font-size:14px;color:' + btn.icon + '"></i>';
+    buttons += "</button>";
+
+    $(document).on("click", "#resetZoom" + graph.graphIdx, function() {
+      Chart.helpers.each(Chart.instances, function(instance) {
+        if (
+          instance.chart.canvas.id ===
+          $("#resetZoom" + graph.graphIdx).data("canvas")
+        ) {
+          instance.chart.resetZoom();
+        }
+      });
     });
   }
 
@@ -1251,7 +1253,7 @@ function getDefaultGraphProperties(graph) {
             }
 
             tooltipEl.removeClass('left right');
-            if (tooltip.yAlign) tooltipEl.addClass(tooltip.xAlign);
+            if (tooltip.yAlign) tooltipEl.removeClass('left right center bottom').addClass(tooltip.xAlign).addClass(tooltip.yAlign);
 
             function getBody(bodyItem) {
               return bodyItem.lines;
@@ -1314,6 +1316,7 @@ function getDefaultGraphProperties(graph) {
       scales: {
         yAxes: [
           {
+            stacked: graph.block.stacked,
             ticks: {
               fontColor: "white",
               source: "auto"
@@ -1326,6 +1329,7 @@ function getDefaultGraphProperties(graph) {
         ],
         xAxes: [
           {
+            stacked: graph.block.stacked,
             offset: true,
             ticks: {
               fontColor: "white",

--- a/js/dashticz.js
+++ b/js/dashticz.js
@@ -21,7 +21,8 @@ var Dashticz = function () {
         'trafficinfo',
         'alarmmeldingen',
         'secpanel',
-		'graph'
+		'graph',
+        'coronavirus'
     ]
     var components = []
     var mountedBlocks = [];


### PR DESCRIPTION
**Update:**
Bar charts can now use stacked: true for stacking multiple datasets in a single bar.
`stacked: true | false,  // default is false`

**Fix:**
Corrected positioning of tooltip when near to X-axis for small values. The tooltip now positions itself above the value, instead of left/right.

**New:**
Coronavirus component, allowing reporting of the current crisis. It uses the dataset of John Hopkins University, which is updated daily. It can report on world stats and also country specific, using the ISO Alpha-2 country codes (link below). https://www.nationsonline.org/oneworld/country_code_list.htm

Example Coronavirus "graph block":
```
blocks['coronavirus_graph_uk'] = {	
	title: 'Coronavirus',
	countryCode:'GB',
	startDate: '01/03/2020',
	datasetColors: ['#7fcdbb', '#f03b20'],
	graph: 'bar',
	startDate: '01/03/2020',
	stacked: true,
	toolTipStyle: true,
	height: '760px',
	zoom: 'x'
} 
```
**countryCode**: 2 character ISO Alpha-2 code for the country to report on. Without this, it will report globally. E.g. Netherlands is NL, Spain is ES, etc. This code is also used to display the flag for the country. 
**startDate**: all data starts on 20/01/2020. The user can specify when they want to report from.
**Note**: many original graph parameters work, such as those in the example above.

![image](https://user-images.githubusercontent.com/33834551/77857691-02705b00-71f7-11ea-952b-104ba997fc50.png)

Example Coronavirus "report block":

```
blocks['coronavirus_gb_confirmed'] = {	
	countryCode:'GB',
	report: 'Confirmed',
	width: 3
} 
```
![image](https://user-images.githubusercontent.com/33834551/77857727-3f3c5200-71f7-11ea-9e28-290b8903efab.png)

Report blocks can be either "global" or "country specific". There are several report options; _Confirmed, Deaths, Ratio_ and _Doubling_. Note, _Doubling_, can only be used with country specific report blocks.

All blocks must be named with "coronavirus_" substring.


