### PR TITLE
Add CORS on some componment

### DIFF
--- a/js/components/coronavirus.js
+++ b/js/components/coronavirus.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-prototype-builtins */
 /* global Dashticz moment settings _CORS_PATH config language time blocks graph Chart _TEMP_SYMBOL getWeekNumber*/
-var api = 'https://cvtapi.nl/v2/';
-var flagUrl = 'https://raw.githubusercontent.com/clinkadink/country-flags/master/png100px/';
+var api = _CORS_PATH + 'https://cvtapi.nl/v2/';
+var flagUrl = _CORS_PATH + 'https://raw.githubusercontent.com/clinkadink/country-flags/master/png100px/';
 var nf = Intl.NumberFormat();
 
 var DT_coronavirus = {

--- a/js/weather_owm.js
+++ b/js/weather_owm.js
@@ -35,7 +35,7 @@ function isNumeric(n) {
 }
 
 function getOWMurl(makeFull) {
-	var site='https://api.openweathermap.org/data/2.5/' + (makeFull? 'forecast':'weather') + '?';
+	var site= _CORS_PATH + 'https://api.openweathermap.org/data/2.5/' + (makeFull? 'forecast':'weather') + '?';
 	if (isNumeric(settings['owm_city']))
 		site += 'id=' + settings['owm_city']
 	else


### PR DESCRIPTION
Firefox is more picky about CORS (and it is right).
It was complaining about OWM and coronna... Now fixed...

Works well on Firefox and chrome / safari .