### PR TITLE
fix Corona name change

### DIFF
--- a/js/components/coronavirus.js
+++ b/js/components/coronavirus.js
@@ -18,7 +18,6 @@ var DT_coronavirus = {
       me.graphIdx = me.primaryIdx;
       me.multigraph = false;
       me.colors = isDefined(me.block.datasetColors)? me.block.datasetColors : ['#7fcdbb', '#f03b20', 'yellow', 'red'];
-      me.name = isDefined(me.block.title) ? me.block.title : me.name.toUpperCase();
       $.extend(me.block, getBlockDefaults(false, true, me.block));
       createDashGraph(me);
     }


### PR DESCRIPTION
Changing the name of the block breaks some code, because the name property should contain the name of the special block.

It's used to determine the correct onResize callback.

I think the name parameter is not used by the Corona block itself, so it should be safe to remove the line.