### PR TITLE
Corona update - "Mode" & Secpanel fix

### DIFF
--- a/js/components/graph.js
+++ b/js/components/graph.js
@@ -1057,7 +1057,7 @@ function createGraph(graph) {
 }
 
 function createHeader(graph, showValues, buttons){
-  var title = '<div class="graphheader"><div class="graphtitle"><i class="fas fa-chart-bar" style="font-size:20px;margin-left:5px;color:' + graph.block.iconColour + '">&nbsp;</i>' + graph.name + '&nbsp;<span class="graphValues' + graph.graphIdx + '">';
+  var title = '<div class="graphheader"><div class="graphtitle"><i class="fas fa-chart-bar" style="font-size:20px;margin-left:5px;color:' + graph.block.iconColour + '">&nbsp;</i>' + graph.title + '&nbsp;<span class="graphValues' + graph.graphIdx + '">';
   var btns = isDefined(buttons)? buttons : '';
   title += "</span></div>";
   var html = "";
@@ -1212,7 +1212,7 @@ function showData(graphIdx){
     html += '   <div class="modal-content" style="background-image:url(' + config['background_image'] + ');">';
     html += '     <div class="modal-header">';
     html += '       <div class="flex-row title">';
-    html += '         <h5 class="modal-title"><i class="fas fa-chart-line"></i>' + graph.name + '</h5>';
+    html += '         <h5 class="modal-title"><i class="fas fa-chart-line"></i>' + graph.title + '</h5>';
     html += '         <div class="btn-group" role="group" aria-label="Graph Debug">';
     html += '           <a type="button" class="btn debug" href="#" onclick="console.log(dtGraphs[\'' + graphIdx + '\']); return false;"><i class="fas fa-code"></i></a>';
     html += '           <a type="button" class="btn debug" href="data:application/octet-stream;charset=utf-16le;base64,' + btoa(JSON.stringify(dtGraphs[graph.graphIdx], null, 2)) + '" download="' + graphIdx + '.json"><i class="fas fa-save"></i></a>';

--- a/js/components/secpanel.js
+++ b/js/components/secpanel.js
@@ -185,7 +185,7 @@ var DT_secpanel = {
           $(".sec-frame .status:not(.dashticz)").removeClass("disabled");
           var mode = $(".sec-frame").last().data("mode");
           if (mode === 2 && status === 2) {
-            window.location = "/";
+            location.reload();
           } else {
             DT_secpanel.ShowStatus();
           }
@@ -321,7 +321,7 @@ $('body').on('click', '.sec-frame .key:not(.disabled)', function () {
   }
 
   if(id === 'dashticz'){
-    window.location = "/"; 
+    location.reload();
     return;
   }
 });


### PR DESCRIPTION
**Update:**

_Corona Block_:
 - Now uses title instead of name (includes a graph.js tweak)
 - Left and right Y axes are now used and labelled "Total" and "Day"
 - User can choose what data to show in the graph using "mode" on the corona block:
```
mode: 0   // both total and day is shown (default)
mode: 1   // only total is shown
mode: 2   // only day is shown 
```
Mode 0: "Both"
![image](https://user-images.githubusercontent.com/33834551/79643260-0d852e00-819a-11ea-92ac-e0046f56dfbd.png)

Mode 1: "Total"
![image](https://user-images.githubusercontent.com/33834551/79643275-2261c180-819a-11ea-8531-d9f2dc1627f0.png)

Mode 2: "Day"
![image](https://user-images.githubusercontent.com/33834551/79643292-37d6eb80-819a-11ea-9265-5ff4cc817c7c.png)

_Security Panel:_
 - @HansieNL spotted this, for some users where Dashticz is not hosted in the root, the previous method  did not reload Dashticz. Now fixed.