### PR TITLE
graphrefactor: header formatting

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -1842,6 +1842,7 @@ canvas {
   -webkit-transform: translate(-50%, 0);
   transform: translate(-50%, 0);
   padding: 10px;
+  z-index: 3;
 }
 
 .chartjs-tooltip.left {

--- a/docs/blocks/graphs.rst
+++ b/docs/blocks/graphs.rst
@@ -168,6 +168,9 @@ The following block parameters can be used to configure the graph:
     - the code automatically calculate if any devices' time data is longer than others. It then use that device's time data, then match all of the devices non-time data to that. This setting allows users to choose to enable or disable that feature (true or false)
   * - customHeader
     - ``customHeader: { ... }`` Customized graph header. See :ref:`customheader`.
+  * - format
+	- | ``false`` (default). Show the value in the graph header as reported by Dashticz.
+	  | ``true``. Format the graph header value using the ``decimals`` parameter and the config settings ``_THOUSAND_SEPARATOR`` and ``_DECIMAL_POINT``. See (todo)
   * - popup
     - ``popup: 'popup_graph'`` Defined Popups. See :ref:`graphs_popups`.
   * - tooltiptotal
@@ -591,6 +594,8 @@ Custom point styling
 customHeader
 ~~~~~~~~~~~~
 
+The parameter ``customheader`` can be a string, function or object. Examples for each type are presented below.
+
 Example of graph showing long data values in header:
 
 .. image :: img/graph_customheader_before.png
@@ -618,6 +623,23 @@ The object accepts key value pairs. Standard Javascript or Jquery code can be us
 Using the updated block (above), the graph now displays like this (below). The unwanted data has been removed, and a new value (the delta between the 2 devices), "1.0 C", has been added:
 
 .. image :: img/graph_customheader_after.png
+
+In case ``customHeader`` is a string, string will be evaluated, and the result added to the graph title::
+
+  customHeader: '"Usage: " + devices[6].Usage + "Delivery: " + devices[6].CurrentDeliv'
+
+The Domoticz devices can be accessed via ``devices[idx]``, as you can see in the previous example.
+
+In case the formatting and/or computation is more complex, you can define customHeader as function::
+
+  customHeader : function(graph) {
+    var devices = Domoticz.getAllDevices();
+	var solarGeneration = devices[6].Usage;
+	var inflow = devices[43].Usage;
+	var outflow = devices[43].UsageDeliv;
+	var nett = inflow + solarGeneration - outflow;
+	return "Nett: " + nett + " Watt";
+	},
 
 
 Custom data


### PR DESCRIPTION
By default header is formatted using decimals parameter, in combination with _THOUSAND_SEPARATOR and _DECIMAL_POINT. The last two are already existing global settings. You set them in CONFIG.js:

_THOUSAND_SEPARATOR = ","l

customHeader can now also be a string (which will used to eval), or a function, returning a string.
