### PR TITLE
Dial update - additional device support

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -1,6 +1,5 @@
 @import url('./plugins.css');
 @import url('./helpers.css');
-
 #loaderHolder {
   position: absolute;
   width: 100%;
@@ -27,11 +26,9 @@
     transform: scale(0.1);
     opacity: 0;
   }
-
   50% {
     opacity: 1;
   }
-
   100% {
     transform: scale(0.8);
     opacity: 0;
@@ -88,8 +85,8 @@
 #loadingMessage {
   width: 100%;
   height: 100%;
-/*  z-index: 1000;*/
-/*  background: #fff;*/
+  /*  z-index: 1000;*/
+  /*  background: #fff;*/
   top: 0px;
   left: 0px;
   position: absolute;
@@ -272,7 +269,7 @@
   overflow-x: hidden;
 }
 
-.newblocksHolder .newblocks > div {
+.newblocksHolder .newblocks>div {
   border: 1px solid #aaa;
   background: rgba(255, 255, 255, 0.2);
   margin: 5px;
@@ -294,17 +291,19 @@
   max-width: 125px;
 }
 
+
 /* BEGIN || Popup modal settings (need to sort and arrange first) */
-.nav-pills > li > a {
+
+.nav-pills>li>a {
   border-radius: 6px 6px 0px 0px;
   color: #000;
   font-size: 16px;
   background-color: #f6f6f6;
 }
 
-.nav-pills > li.active > a,
-.nav-pills > li.active > a:focus,
-.nav-pills > li.active > a:hover {
+.nav-pills>li.active>a,
+.nav-pills>li.active>a:focus,
+.nav-pills>li.active>a:hover {
   background-color: #555;
 }
 
@@ -312,9 +311,11 @@
   border-bottom: 0px !important;
 }
 
+
 /*
 next css sets the default height of the frame popup
 */
+
 .popupheight {
   height: calc(95vh - 150px);
 }
@@ -382,18 +383,18 @@ next css sets the default height of the frame popup
   width: 80%;
 }
 
-.material-switch > input[type='checkbox'] {
+.material-switch>input[type='checkbox'] {
   display: none;
 }
 
-.material-switch > label {
+.material-switch>label {
   cursor: pointer;
   height: 0px;
   position: relative;
   width: 40px;
 }
 
-.material-switch > label::before {
+.material-switch>label::before {
   background: rgb(0, 0, 0);
   box-shadow: inset 0px 0px 10px rgba(0, 0, 0, 0.5);
   border-radius: 8px;
@@ -406,7 +407,7 @@ next css sets the default height of the frame popup
   width: 40px;
 }
 
-.material-switch > label::after {
+.material-switch>label::after {
   background: rgb(255, 255, 255);
   border-radius: 16px;
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
@@ -420,15 +421,16 @@ next css sets the default height of the frame popup
   width: 24px;
 }
 
-.material-switch > input[type='checkbox']:checked + label::before {
+.material-switch>input[type='checkbox']:checked+label::before {
   background: inherit;
   opacity: 0.5;
 }
 
-.material-switch > input[type='checkbox']:checked + label::after {
+.material-switch>input[type='checkbox']:checked+label::after {
   background: inherit;
   left: 20px;
 }
+
 
 /* END || Popup modal settings (need to sort and arrange first) */
 
@@ -577,7 +579,6 @@ a.playlist {
   max-width: 100%;
   color: #fff !important;
   background-color: transparent;
-
   border: 0px;
   padding-left: 0px;
 }
@@ -606,6 +607,7 @@ a.playlist {
   height: 77px;
   margin: 5px;
 }
+
 
 /* Thermostat CSS: */
 
@@ -644,11 +646,9 @@ a.playlist {
   margin: auto;
 }
 
-.btn.plus {
-}
+.btn.plus {}
 
-.btn.min {
-}
+.btn.min {}
 
 .btn.stop {
   transform: rotate(90deg);
@@ -735,8 +735,8 @@ a.playlist {
   line-height: 1em;
 }
 
-@media only screen and (max-width: 1000px) {
-}
+@media only screen and (max-width: 1000px) {}
+
 
 /************************/
 
@@ -751,6 +751,7 @@ a.playlist {
   color: #bbb;
   white-space: nowrap;
 }
+
 
 /*To change the default height of the graph popup adapt the height value in custom.css
   Example:
@@ -773,7 +774,9 @@ a.playlist {
   height: calc(100vh - 250px);
 }
 
+
 /* graphwidth for small screens.*/
+
 .graphwidth {
   min-width: 30px;
   width: 100vw;
@@ -1062,7 +1065,7 @@ p {
   margin-bottom: 20px;
 }
 
-.row > div {
+.row>div {
   padding-right: 0px !important;
   padding-left: 0px !important;
 }
@@ -1126,9 +1129,11 @@ p {
   padding-top: 6px !important;
 }
 
+
 /*
 Only add this hover on NON touch devices
 */
+
 @media (hover: hover) {
   .transbg.col-xs-1.hover:hover,
   .transbg.col-xs-2.hover:hover,
@@ -1249,18 +1254,6 @@ Only add this hover on NON touch devices
   margin-right: 7px;
 }
 
-.rgbcontainer {
-  display: flex
-}
-
-.rgbcontainer .slider {
-  width: 100%
-}
-
-.rgbcontainer .rgbholder {
-  flex: 0 0 50px
-}
-
 .weekday {
   margin-bottom: 5px;
 }
@@ -1321,27 +1314,27 @@ html .ui-button.ui-state-disabled:active {
   text-transform: uppercase;
 }
 
-.navbar-default .nav > li > a,
-.navbar-default .nav > li > a:focus {
+.navbar-default .nav>li>a,
+.navbar-default .nav>li>a:focus {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 13px;
   color: #222222;
 }
 
-.navbar-default .nav > li > a:hover,
-.navbar-default .nav > li > a:focus:hover {
+.navbar-default .nav>li>a:hover,
+.navbar-default .nav>li>a:focus:hover {
   color: #f05f40;
 }
 
-.navbar-default .nav > li.active > a,
-.navbar-default .nav > li.active > a:focus {
+.navbar-default .nav>li.active>a,
+.navbar-default .nav>li.active>a:focus {
   color: #f05f40 !important;
   background-color: transparent;
 }
 
-.navbar-default .nav > li.active > a:hover,
-.navbar-default .nav > li.active > a:focus:hover {
+.navbar-default .nav>li.active>a:hover,
+.navbar-default .nav>li.active>a:focus:hover {
   background-color: transparent;
 }
 
@@ -1350,48 +1343,39 @@ html .ui-button.ui-state-disabled:active {
     background-color: transparent;
     border-color: rgba(255, 255, 255, 0.3);
   }
-
   .navbar-default .navbar-header .navbar-brand {
     color: rgba(255, 255, 255, 0.7);
   }
-
   .navbar-default .navbar-header .navbar-brand:hover,
   .navbar-default .navbar-header .navbar-brand:focus {
     color: white;
   }
-
-  .navbar-default .nav > li > a,
-  .navbar-default .nav > li > a:focus {
+  .navbar-default .nav>li>a,
+  .navbar-default .nav>li>a:focus {
     color: rgba(255, 255, 255, 0.7);
   }
-
-  .navbar-default .nav > li > a:hover,
-  .navbar-default .nav > li > a:focus:hover {
+  .navbar-default .nav>li>a:hover,
+  .navbar-default .nav>li>a:focus:hover {
     color: white;
   }
-
   .navbar-default.affix {
     background-color: white;
     border-color: rgba(34, 34, 34, 0.05);
   }
-
   .navbar-default.affix .navbar-header .navbar-brand {
     color: #f05f40;
     font-size: 14px;
   }
-
   .navbar-default.affix .navbar-header .navbar-brand:hover,
   .navbar-default.affix .navbar-header .navbar-brand:focus {
     color: #eb3812;
   }
-
-  .navbar-default.affix .nav > li > a,
-  .navbar-default.affix .nav > li > a:focus {
+  .navbar-default.affix .nav>li>a,
+  .navbar-default.affix .nav>li>a:focus {
     color: #222222;
   }
-
-  .navbar-default.affix .nav > li > a:hover,
-  .navbar-default.affix .nav > li > a:focus:hover {
+  .navbar-default.affix .nav>li>a:hover,
+  .navbar-default.affix .nav>li>a:focus:hover {
     color: #f05f40;
   }
 }
@@ -1427,11 +1411,9 @@ img.icon {
   div.mh {
     height: 75px;
   }
-
   .big .weatherdegrees {
     padding-left: 15px;
   }
-
   .transbg.col-xs-1,
   .transbg.col-xs-2,
   .transbg.col-xs-3,
@@ -1447,92 +1429,72 @@ img.icon {
     padding-top: 7px;
     padding-bottom: 7px;
   }
-
   .dt_block {
     padding: 2px !important;
   }
-
   .dt_title,
   .dt_state {
     margin: 2px 2px;
   }
-
   .dt_block .col-icon {
     width: 36px !important;
     margin: 2px;
   }
-
   .button .dt_state,
   .frame .dt_state {
     margin: -2px;
   }
-
   .dt_title {
     font-size: 100%;
   }
-
   .cast-button-container {
     padding: 3px !important;
   }
-
   h1,
   h4 {
     margin-left: 0px !important;
   }
-
   div.big {
     padding-left: 13px !important;
   }
-
   .containsweather .col-xs-1 {
     width: 35px;
   }
-
   .containsweather .col-xs-11 {
     width: calc(100% - 35px);
   }
-
   img.icon {
     max-width: 15px !important;
   }
-
   .fas,
   .far,
   .fab,
   .wi {
     font-size: 15px !important;
   }
-
   .fa-tv:before {
     font-size: 12px;
   }
-
   .big .wi {
     font-size: 30px !important;
   }
-
   .col-icon {
     max-width: 26px !important;
   }
-
   .col-data {
     width: calc(100% - 30px);
   }
-
   .btn.stop {
     top: 14px;
     width: 60px;
     right: -14px;
   }
-
   .trashcan {
     max-width: 15px !important;
   }
-
   .iconheating {
     margin-top: 0px;
   }
-
   .title-input {
     font-size: 14px !important;
     margin-top: 0px;
@@ -1566,28 +1528,28 @@ div.screen {
   text-shadow: none;
 }
 
-.weatherfull > div div {
+.weatherfull>div div {
   text-align: center;
   color: #fff;
 }
 
-.weatherfull > div div.day {
+.weatherfull>div div.day {
   margin-top: 0px;
   font-weight: 300;
   font-size: 13px;
 }
 
-.weatherfull > div div.temp span {
+.weatherfull>div div.temp span {
   float: none;
   display: inline-block;
 }
 
-.weatherfull > div div.temp {
+.weatherfull>div div.temp {
   font-size: 28px;
   font-weight: 400;
 }
 
-.weatherfull > div div.temp .nightT {
+.weatherfull>div div.temp .nightT {
   display: block;
   font-size: 19px;
   margin-top: -8px;
@@ -1595,14 +1557,14 @@ div.screen {
   padding-bottom: 0px;
 }
 
-.weatherfull > div div.icon {
+.weatherfull>div div.icon {
   border-radius: 50%;
   width: 75px;
   height: 48px;
   margin: 0px auto;
 }
 
-.weatherfull > div div.icon i {
+.weatherfull>div div.icon i {
   color: #fff !important;
 }
 
@@ -1620,7 +1582,7 @@ div.screen {
   color: #f05f40;
 }
 
-.no-gutter > [class*='col-'] {
+.no-gutter>[class*='col-'] {
   padding-right: 0;
   padding-left: 0;
 }
@@ -1639,7 +1601,7 @@ div.screen {
 .btn-default.focus,
 .btn-default:active,
 .btn-default.active,
-.open > .dropdown-toggle.btn-default {
+.open>.dropdown-toggle.btn-default {
   color: #222222;
   background-color: #f2f2f2;
   border-color: #ededed;
@@ -1647,7 +1609,7 @@ div.screen {
 
 .btn-default:active,
 .btn-default.active,
-.open > .dropdown-toggle.btn-default {
+.open>.dropdown-toggle.btn-default {
   background-image: none;
 }
 
@@ -1692,7 +1654,7 @@ fieldset[disabled] .btn-default.active {
 .btn-primary.focus,
 .btn-primary:active,
 .btn-primary.active,
-.open > .dropdown-toggle.btn-primary {
+.open>.dropdown-toggle.btn-primary {
   color: white;
   background-color: #ee4b28;
   border-color: #ed431f;
@@ -1700,7 +1662,7 @@ fieldset[disabled] .btn-default.active {
 
 .btn-primary:active,
 .btn-primary.active,
-.open > .dropdown-toggle.btn-primary {
+.open>.dropdown-toggle.btn-primary {
   background-image: none;
 }
 
@@ -1884,7 +1846,9 @@ a:not([href]) {
   cursor: pointer;
 }
 
+
 /* EVOHOME START */
+
 .text-grey {
   color: #bbb;
   white-space: nowrap;
@@ -1909,6 +1873,7 @@ a:not([href]) {
 .hide {
   display: none !important;
 }
+
 
 /* EVOHOME END */
 
@@ -1941,7 +1906,9 @@ a:not([href]) {
   min-width: 50%;
 }
 
+
 /* START: NEWS BLOCK*/
+
 #newsTicker {
   margin: 10px 0 0 15px;
   color: #333;
@@ -1999,9 +1966,12 @@ a:not([href]) {
   overflow: hidden;
 }
 
+
 /* END: NEWS BLOCK */
 
+
 /* START: TOOLTIPSTYLE */
+
 canvas {
   -moz-user-select: none;
   -webkit-user-select: none;
@@ -2117,9 +2087,12 @@ canvas {
   margin-right: 5px;
 }
 
+
 /* END: TOOLTIPSTYLE */
 
+
 /* START: GRAPH-MENU DEBUG */
+
 .flex-row {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -2179,7 +2152,7 @@ canvas {
   padding-right: 5px;
 }
 
-.graph-menu div:not(.debug) > .fas {
+.graph-menu div:not(.debug)>.fas {
   padding-right: 5px;
 }
 
@@ -2257,9 +2230,12 @@ canvas {
   background-color: white;
 }
 
+
 /* END: GRAPH-MENU DEBUG */
 
+
 /* START: CAMERA COMPONENT */
+
 .cam-container,
 .cam-container .stream {
   width: 100%;
@@ -2273,7 +2249,7 @@ canvas {
 .cam-container .carousel-inner {
   position: relative;
   width: 100%;
-  overflow: visible!important; 
+  overflow: visible!important;
 }
 
 .cam-container .stream {
@@ -2313,6 +2289,7 @@ canvas {
   position: relative;
   bottom: 15%;
 }
+
 .cam-container .handle {
   position: absolute;
   width: 5%;
@@ -2331,7 +2308,7 @@ canvas {
   border: 0;
   box-shadow: inset 0px 4px 15px 0px rgba(0, 0, 0, 0.7);
   transition: all 0.1s ease-in-out;
-	animation: pulse 2s infinite;
+  animation: pulse 2s infinite;
 }
 
 .cam-container .handle:hover {
@@ -2350,27 +2327,28 @@ canvas {
 
 @-webkit-keyframes pulse {
   0% {
-    -webkit-box-shadow: 0 0 10px 5px rgba(0,0,0,0.4);
+    -webkit-box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.4);
   }
   70% {
-      -webkit-box-shadow: 0 0 6px 3px rgba(0,0,0,0);
+    -webkit-box-shadow: 0 0 6px 3px rgba(0, 0, 0, 0);
   }
   100% {
-      -webkit-box-shadow: 0 0 2px 1px rgba(0,0,0,0);
+    -webkit-box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0);
   }
 }
+
 @keyframes pulse {
   0% {
-    -moz-box-shadow: 0 0 10px 5px rgba(0,0,0,0.4);
-    box-shadow: 0 0 10px 5px rgba(0,0,0,0.4);
+    -moz-box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.4);
   }
   70% {
-      -moz-box-shadow: 0 0 6px 3px rgba(0,0,0,0);
-      box-shadow: 0 0 6px 3px rgba(0,0,0,0);
+    -moz-box-shadow: 0 0 6px 3px rgba(0, 0, 0, 0);
+    box-shadow: 0 0 6px 3px rgba(0, 0, 0, 0);
   }
   100% {
-      -moz-box-shadow: 0 0 2px 1px rgba(0,0,0,0);
-      box-shadow: 0 0 2px 1px rgba(0,0,0,0);
+    -moz-box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0);
+    box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0);
   }
 }
 
@@ -2383,9 +2361,8 @@ canvas {
   height: 13vh;
   width: auto;
   border-radius: 20px;
-  box-shadow: 0px 5px 10px 5px rgba(0,0,0,0.7);
+  box-shadow: 0px 5px 10px 5px rgba(0, 0, 0, 0.7);
 }
-
 
 .cam-container .btn-group {
   top: 0;
@@ -2405,7 +2382,7 @@ canvas {
 .cam-container .cam-caption {
   position: absolute;
   color: #fff;
-  text-shadow: 0 1px 2px rgba(0,0,0,.6);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, .6);
   z-index: 30;
   right: 3%;
   margin-top: 1%;
@@ -2420,36 +2397,7 @@ canvas {
 }
 
 .carbon {
-  background:
-    linear-gradient(27deg, 
-      #151515 5px, 
-      transparent 5px
-    ) 0 5px,
-    linear-gradient(207deg, 
-      #151515 5px, 
-      transparent 5px
-    ) 10px 0px,
-    linear-gradient(27deg, 
-      #222 5px, 
-      transparent 5px
-    ) 0px 10px,
-    linear-gradient(207deg, 
-      #222 5px, 
-      transparent 5px
-    ) 10px 5px,
-    linear-gradient(90deg, 
-      #1b1b1b 10px, 
-      transparent 10px
-    ),
-    linear-gradient(
-      #1d1d1d 25%, 
-      #1a1a1a 25%, 
-      #1a1a1a 50%, 
-      transparent 50%, 
-      transparent 75%, 
-      #242424 75%, 
-      #242424
-    );
+  background: linear-gradient(27deg, #151515 5px, transparent 5px) 0 5px, linear-gradient(207deg, #151515 5px, transparent 5px) 10px 0px, linear-gradient(27deg, #222 5px, transparent 5px) 0px 10px, linear-gradient(207deg, #222 5px, transparent 5px) 10px 5px, linear-gradient(90deg, #1b1b1b 10px, transparent 10px), linear-gradient( #1d1d1d 25%, #1a1a1a 25%, #1a1a1a 50%, transparent 50%, transparent 75%, #242424 75%, #242424);
   background-color: #131313;
   background-size: 20px 20px;
   background-clip: content-box;
@@ -2458,7 +2406,9 @@ canvas {
 
 /* END: CAMERA COMPONENT */
 
+
 /* START: CORONAVIRUS */
+
 .coronavirus .graphheader {
   height: 20px;
 }
@@ -2507,9 +2457,12 @@ canvas {
   vertical-align: middle;
 }
 
+
 /* END: CORONAVIRUS */
 
+
 /* START: AGENDA */
+
 .agenda table {
   border-collapse: separate;
   border-spacing: 10px 0px;
@@ -2524,9 +2477,12 @@ td.agenda-title {
   white-space: normal;
 }
 
+
 /* END: AGENDA */
 
+
 /* START: NEW CALENDAR */
+
 .cal_table {
   border-collapse: collapse;
   height: 100% !important;
@@ -2558,7 +2514,7 @@ td.agenda-title {
   text-align: left;
 }
 
-.cal_table td > div {
+.cal_table td>div {
   text-align: center;
 }
 
@@ -2566,36 +2522,36 @@ td.agenda-title {
   white-space: wrap !important;
 }
 
-.cal_table td > div.historic > div {
+.cal_table td>div.historic>div {
   color: rgba(255, 255, 255, 0.3) !important;
 }
 
-.cal_table td > div.header {
+.cal_table td>div.header {
   background-color: #484848;
   max-width: inherit;
 }
 
-.cal_table td > div.today {
+.cal_table td>div.today {
   background-color: #0275d8;
 }
 
-.cal_table td > div.event:hover,
-.cal_table td > div.event.historic:hover > div {
+.cal_table td>div.event:hover,
+.cal_table td>div.event.historic:hover>div {
   background-color: #f0ad4e !important;
   color: #292b2c !important;
 }
 
-.cal_table td > div.allday {
+.cal_table td>div.allday {
   background-color: #d9534f !important;
   border-radius: 2px;
 }
 
-.cal_table td > div.allday.hol {
+.cal_table td>div.allday.hol {
   background-color: #428442 !important;
   border-radius: 2px;
 }
 
-.cal_table td > div:not(:first-child) {
+.cal_table td>div:not(:first-child) {
   display: inline-flex;
   margin: 3px 5px;
   display: flex;
@@ -2623,18 +2579,18 @@ td.agenda-title {
   border-radius: 5px;
 }
 
-.cal-modal > .cal-title {
+.cal-modal>.cal-title {
   font-size: 1.8em;
   font-weight: 900;
   margin-bottom: 10px;
   padding-bottom: 5px;
 }
 
-.cal-modal > .cal-title > .far {
+.cal-modal>.cal-title>.far {
   float: right !important;
 }
 
-.cal-modal > .cal-info {
+.cal-modal>.cal-info {
   overflow-y: auto;
   height: calc(100% - 55px);
   border-bottom: solid 1px #bebebe;
@@ -2642,7 +2598,7 @@ td.agenda-title {
   padding-top: 10px;
 }
 
-.cal-modal > .cal-footer {
+.cal-modal>.cal-footer {
   bottom: 0px !important;
   position: absolute;
   width: 93%;
@@ -2656,43 +2612,42 @@ td.agenda-title {
   position: absolute;
 }
 
-.cal-modal > .cal-footer a {
+.cal-modal>.cal-footer a {
   color: grey;
 }
 
-.cal-modal > .cal-footer a:hover {
+.cal-modal>.cal-footer a:hover {
   color: dodgerblue;
 }
 
-.cal-modal > .cal-footer a:nth-child(1) {
+.cal-modal>.cal-footer a:nth-child(1) {
   float: left;
 }
 
-.cal-modal > .cal-footer a:nth-child(2) {
+.cal-modal>.cal-footer a:nth-child(2) {
   float: right;
 }
 
 @media screen and (max-width: 1400px) and (max-height: 800px) {
-  .cal_table td > div:first-child {
+  .cal_table td>div:first-child {
     text-align: center;
   }
-
   .cal_table td div {
     font-size: 0.9em;
     text-align: left;
   }
 }
 
+
 /* END: CALENDAR */
 
+
 /* START: SECURITY PANEL */
+
 @font-face {
   font-family: 'Audiowide';
   src: url('../font/Audiowide.eot');
-  src: url('../font/Audiowide.eot?#iefix') format('embedded-opentype'),
-    url('../font/Audiowide.woff') format('woff'),
-    url('../font/Audiowide.ttf') format('truetype'),
-    url('../font/Audiowide.svg#../font/Audiowide-7Italic') format('svg');
+  src: url('../font/Audiowide.eot?#iefix') format('embedded-opentype'), url('../font/Audiowide.woff') format('woff'), url('../font/Audiowide.ttf') format('truetype'), url('../font/Audiowide.svg#../font/Audiowide-7Italic') format('svg');
 }
 
 .sec-modal {
@@ -2727,9 +2682,7 @@ td.agenda-title {
   background-image: url(../img/bg14.jpg);
   -webkit-box-shadow: 10px 10px 5px 0px rgba(0, 0, 0, 0.75);
   -moz-box-shadow: 10px 10px 5px 0px rgba(0, 0, 0, 0.75);
-  box-shadow: 0px 6px 20px 5px rgba(0, 0, 0, 0.75),
-    inset 0px 5px 7px -2px rgba(252, 252, 252, 0.2),
-    inset 0 -14px 8px 2px rgba(0, 0, 0, 0.7);
+  box-shadow: 0px 6px 20px 5px rgba(0, 0, 0, 0.75), inset 0px 5px 7px -2px rgba(252, 252, 252, 0.2), inset 0 -14px 8px 2px rgba(0, 0, 0, 0.7);
   border-radius: 5px;
   position: relative;
   height: 100%;
@@ -2837,9 +2790,7 @@ td.agenda-title {
   border-radius: 3px;
   background-color: #161616;
   border: 0;
-  box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5),
-    inset 0px 0px 15px 5px rgba(0, 0, 0, 0.8);
+  box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 3px rgba(255, 255, 255, 0.5), inset 0px 0px 15px 5px rgba(0, 0, 0, 0.8);
   color: #8fffd0;
   font-family: monospace;
   text-align: center;
@@ -2873,15 +2824,9 @@ td.agenda-title {
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  -webkit-box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 0.3),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
-  -moz-box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 0.3),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
-  box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 0.3),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  -webkit-box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  -moz-box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  box-shadow: 0px 11px 22px #000000, 0px 3px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
   font-family: monospace;
   text-transform: uppercase;
   font-weight: 900;
@@ -2897,15 +2842,9 @@ td.agenda-title {
 
 .sec-frame .keypad-input .key:not(.disabled):active {
   transform: scale(0.9);
-  -webkit-box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 1),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
-  -moz-box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 1),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
-  box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4),
-    inset 0px 1px 0px rgba(255, 255, 255, 1),
-    inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  -webkit-box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 1), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  -moz-box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 1), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
+  box-shadow: 0px 2px 6px #000000, 0px 15px 15px rgba(0, 0, 0, 0.4), inset 0px 1px 0px rgba(255, 255, 255, 1), inset 0px 0px 3px rgba(255, 255, 255, 0.5);
 }
 
 .sec-frame .keypad-input .key.h {
@@ -2944,8 +2883,7 @@ td.agenda-title {
   font-weight: 900;
   font-size: 100%;
   color: rgba(130, 130, 130, 0.8);
-  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.8), 0 0 0 #000,
-    1px 1px 3px rgba(255, 255, 255, 0.7);
+  text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.8), 0 0 0 #000, 1px 1px 3px rgba(255, 255, 255, 0.7);
 }
 
 .sec-frame .keypad-input .status[data-id='disarm']:before {
@@ -2985,100 +2923,18 @@ td.agenda-title {
   width: 5%;
   height: 4%;
   border-radius: 100%;
-  background: -moz-linear-gradient(
-    -45deg,
-    #adadad 0%,
-    #e1e1e1 51%,
-    #dddddd 68%,
-    #f6f6f6 100%
-  );
-  background: -webkit-gradient(
-    linear,
-    left top,
-    right bottom,
-    color-stop(0%, #adadad),
-    color-stop(51%, #e1e1e1),
-    color-stop(68%, #dddddd),
-    color-stop(100%, #f6f6f6)
-  );
-  background: -webkit-linear-gradient(
-    -45deg,
-    #adadad 0%,
-    #e1e1e1 51%,
-    #dddddd 68%,
-    #f6f6f6 100%
-  );
-  background: -o-linear-gradient(
-    -45deg,
-    #adadad 0%,
-    #e1e1e1 51%,
-    #dddddd 68%,
-    #f6f6f6 100%
-  );
-  background: -ms-linear-gradient(
-    -45deg,
-    #adadad 0%,
-    #e1e1e1 51%,
-    #dddddd 68%,
-    #f6f6f6 100%
-  );
-  background: linear-gradient(
-    135deg,
-    #adadad 0%,
-    #e1e1e1 51%,
-    #dddddd 68%,
-    #f6f6f6 100%
-  );
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#adadad', endColorstr='#f6f6f6', GradientType=1);
+  background: -moz-linear-gradient( -45deg, #adadad 0%, #e1e1e1 51%, #dddddd 68%, #f6f6f6 100%);
+  background: -webkit-gradient( linear, left top, right bottom, color-stop(0%, #adadad), color-stop(51%, #e1e1e1), color-stop(68%, #dddddd), color-stop(100%, #f6f6f6));
+  background: -webkit-linear-gradient( -45deg, #adadad 0%, #e1e1e1 51%, #dddddd 68%, #f6f6f6 100%);
+  background: -o-linear-gradient( -45deg, #adadad 0%, #e1e1e1 51%, #dddddd 68%, #f6f6f6 100%);
+  background: -ms-linear-gradient( -45deg, #adadad 0%, #e1e1e1 51%, #dddddd 68%, #f6f6f6 100%);
+  background: linear-gradient( 135deg, #adadad 0%, #e1e1e1 51%, #dddddd 68%, #f6f6f6 100%);
+  filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#adadad', endColorstr='#f6f6f6', GradientType=1);
   -moz-box-shadow: 0px 2px 4px #000;
   -webkit-box-shadow: 0px 2px 4px #000;
   box-shadow: 0px 2px 4px #000, -1px 3px 10px 7px rgba(0, 0, 0, 0.5);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background-image: -webkit-radial-gradient(
-      50% 0%,
-      8% 50%,
-      hsla(0, 0%, 100%, 0.5) 0%,
-      hsla(0, 0%, 100%, 0) 100%
-    ),
-    -webkit-radial-gradient(50% 100%, 12% 50%, hsla(0, 0%, 100%, 0.6) 0%, hsla(
-            0,
-            0%,
-            100%,
-            0
-          )
-          100%),
-    -webkit-radial-gradient(0% 50%, 50% 7%, hsla(0, 0%, 100%, 0.5) 0%, hsla(
-            0,
-            0%,
-            100%,
-            0
-          )
-          100%),
-    -webkit-radial-gradient(100% 50%, 50% 5%, hsla(0, 0%, 100%, 0.5) 0%, hsla(
-            0,
-            0%,
-            100%,
-            0
-          )
-          100%),
-    -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 0%, 0) 0%, hsla(
-            0,
-            0%,
-            0%,
-            0
-          )
-          3%, hsla(0, 0%, 0%, 0.1) 3.5%),
-    -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 100%, 0)
-          0%, hsla(0, 0%, 100%, 0) 6%, hsla(0, 0%, 100%, 0.1) 7.5%),
-    -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 100%, 0)
-          0%, hsla(0, 0%, 100%, 0) 1.2%, hsla(0, 0%, 100%, 0.2) 2.2%),
-    -webkit-radial-gradient(50% 50%, 200% 50%, hsla(0, 0%, 90%, 1) 5%, hsla(
-            0,
-            0%,
-            85%,
-            1
-          )
-          30%, hsla(0, 0%, 60%, 1) 100%);
+  background-image: -webkit-radial-gradient( 50% 0%, 8% 50%, hsla(0, 0%, 100%, 0.5) 0%, hsla(0, 0%, 100%, 0) 100%), -webkit-radial-gradient(50% 100%, 12% 50%, hsla(0, 0%, 100%, 0.6) 0%, hsla( 0, 0%, 100%, 0) 100%), -webkit-radial-gradient(0% 50%, 50% 7%, hsla(0, 0%, 100%, 0.5) 0%, hsla( 0, 0%, 100%, 0) 100%), -webkit-radial-gradient(100% 50%, 50% 5%, hsla(0, 0%, 100%, 0.5) 0%, hsla( 0, 0%, 100%, 0) 100%), -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 0%, 0) 0%, hsla( 0, 0%, 0%, 0) 3%, hsla(0, 0%, 0%, 0.1) 3.5%), -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 100%, 0) 0%, hsla(0, 0%, 100%, 0) 6%, hsla(0, 0%, 100%, 0.1) 7.5%), -webkit-repeating-radial-gradient(50% 50%, 100% 100%, hsla(0, 0%, 100%, 0) 0%, hsla(0, 0%, 100%, 0) 1.2%, hsla(0, 0%, 100%, 0.2) 2.2%), -webkit-radial-gradient(50% 50%, 200% 50%, hsla(0, 0%, 90%, 1) 5%, hsla( 0, 0%, 85%, 1) 30%, hsla(0, 0%, 60%, 1) 100%);
   opacity: 0.5;
 }
 
@@ -3089,7 +2945,6 @@ td.agenda-title {
   transform: rotate(150deg);
   -ms-transform: rotate(150deg);
   -webkit-transform: rotate(150deg);
-
   height: 29%;
   width: 135%;
   margin-top: 41%;
@@ -3125,7 +2980,9 @@ td.agenda-title {
   display: none;
 }
 
+
 /* END: SECURITY PANEL */
+
 
 /* START: DIAL */
 
@@ -3159,12 +3016,11 @@ td.agenda-title {
   -o-border-radius: 50%;
   border-radius: 50%;
   float: left;
-  background-color: #cccccc;
+  background-color: #8b8b8b;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 5px 10px 2px rgba(0, 0, 0, 0.3),
-    inset 0px 0px 6px 0px rgba(0, 0, 0, 1);
+  box-shadow: 0 5px 10px 2px rgba(0, 0, 0, 0.3), inset 0px 0px 6px 0px rgba(0, 0, 0, 1);
 }
 
 .dial:hover {
@@ -3185,7 +3041,9 @@ td.agenda-title {
 
 .dial.p0 .bar,
 .dial.p180 .bar,
-.dial.p180 .fill {
+.dial.p180 .fill,
+.dial.p360 .bar,
+.dial.p360 .fill {
   position: absolute;
   border: 0.08em solid #307bbb;
   width: 0.78em;
@@ -3209,13 +3067,19 @@ td.agenda-title {
   transform: rotate(0deg);
 }
 
-.dial.p180 .fill {
+.dial.p180 .fill,
+.dial.p360 .fill {
   clip: rect(0em, 0.5em, 1em, 0em);
   -webkit-transform: scaleX(-1) rotate(360deg);
   -moz-transform: scaleX(-1) rotate(360deg);
   -ms-transform: scaleX(-1) rotate(360deg);
   -o-transform: scaleX(-1) rotate(360deg);
   transform: scaleX(-1) rotate(360deg);
+}
+
+.dial.p360 .bar,
+.dial.p360 .fill {
+  clip: auto;
 }
 
 .dial .bar.primary,
@@ -3227,6 +3091,16 @@ td.agenda-title {
 .dial .bar.secondary,
 .dial .fill.secondary {
   border-color: #307bbb;
+}
+
+.dial .bar.positive,
+.dial .fill.positive {
+  border-color: #28a745;
+}
+
+.dial .bar.negative,
+.dial .fill.negative {
+  border-color: #dc3545;
 }
 
 .dial.p180 .fill:after {
@@ -3276,16 +3150,27 @@ td.agenda-title {
 
 .dial .slice {
   position: absolute;
-  width: 1em;
-  height: 1em;
+  width: 100%;
+  height: 100%;
   transform: rotate(-140deg);
 }
-.dial:not(.p180) .slice,
+
+.dial .slice.splitdial-plus {
+  transform: rotateY(0deg) rotateX(0deg)!important;
+}
+
+.dial .slice.splitdial-minus {
+  transform: rotate(180deg)!important;
+}
+
+.dial:not(.p180):not(.p360) .slice,
 .dial.p0 .slice {
   clip: rect(0em, 1em, 1em, 0.5em);
 }
-.dial.p180 .slice {
-  clip: rect(0em, 1em, 1em, 0em);
+
+.dial.p180 .slice,
+.dial.p360 .slice {
+  clip: rect(0em, 1em, 1em, 0em)!important;
 }
 
 .dial .dial-container {
@@ -3352,8 +3237,7 @@ td.agenda-title {
   justify-content: center;
   border-radius: 50%;
   background: radial-gradient(circle, #333, #444);
-  box-shadow: inset 0 0 3px 0px rgba(0, 0, 0, 0.5),
-    0 0 11px 0px rgba(0, 0, 0, 0.8);
+  box-shadow: inset 0 0 3px 0px rgba(0, 0, 0, 0.5), 0 0 11px 0px rgba(0, 0, 0, 0.8);
   -webkit-transition: all 0.2s ease-in;
   -moz-transition: all 0.2s ease-in;
   -o-transition: all 0.2s ease-in;
@@ -3403,9 +3287,7 @@ td.agenda-title {
   -moz-text-align-last: center;
   border-radius: 50%;
   margin-top: 10px;
-  box-shadow: inset 0px 0.5px 0px rgba(255, 255, 255, 0.3),
-    inset 0px 0px 2px rgba(255, 255, 255, 0.5),
-    inset 0px 5px 8px 5px rgba(0, 0, 0, 0.8);
+  box-shadow: inset 0px 0.5px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 2px rgba(255, 255, 255, 0.5), inset 0px 5px 8px 5px rgba(0, 0, 0, 0.8);
   color: #cccccc;
   background-color: #2a2a2a;
   border: 0;
@@ -3431,14 +3313,7 @@ td.agenda-title {
 }
 
 .dial-menu .status li.selected {
-  background: linear-gradient(
-    to right,
-    black 0%,
-    #29261f 8%,
-    var(--dial-color) 50%,
-    #29261f 92%,
-    black 100%
-  );
+  background: linear-gradient( to right, black 0%, #29261f 8%, var(--dial-color) 50%, #29261f 92%, black 100%);
   color: #393939;
   -moz-box-shadow: 5px 0px 15px rgba(0, 0, 0, 0.5);
   -webkit-box-shadow: 5px 0px 15px rgba(0, 0, 0, 0.5);
@@ -3449,7 +3324,7 @@ td.agenda-title {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background: linear-gradient(0deg, #222, #444, #333);
+  background: linear-gradient(0deg, #181818, #444, #4b4b4b);
   -webkit-box-shadow: inset 0px 0px 20px 5px rgba(0, 0, 0, 0.5);
   -moz-box-shadow: inset 0px 0px 20px 5px rgba(0, 0, 0, 0.5);
   box-shadow: inset 0px 0px 20px 5px rgba(0, 0, 0, 0.5);
@@ -3466,7 +3341,7 @@ td.agenda-title {
 .dial .dial-needle::before {
   content: '';
   position: absolute;
-  left: 37%;
+  left: 35%;
   top: -53%;
   border-left: var(--needle-width) solid transparent;
   border-right: var(--needle-width) solid transparent;
@@ -3480,8 +3355,8 @@ td.agenda-title {
 .dial .dial-needle::after {
   content: '';
   position: absolute;
-  left: 37%;
-  top: -53%;
+  left: 36%;
+  top: -49%;
   border-left: var(--needle-width) solid transparent;
   border-right: var(--needle-width) solid transparent;
   border-bottom: var(--needle-length) solid rgba(0, 0, 0, 1);
@@ -3503,6 +3378,7 @@ td.agenda-title {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  flex-direction: column;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   align-items: center;
@@ -3510,8 +3386,16 @@ td.agenda-title {
   height: 90%;
 }
 
-.dial .dial-display .value {
-  font-size: 0.25em;
+.dial .dial-display .value-unit {
+  position: absolute;
+  top: 30%;
+  display: flex;
+  align-items: center;
+}
+
+.dial .dial-display .value-unit .value,
+.dial .dial-display .value-unit .unit {
+  font-size: 0.22em;
   line-height: 1em;
   color: #cccccc;
   -webkit-transition: all 0.2s ease-out;
@@ -3522,51 +3406,89 @@ td.agenda-title {
   z-index: 5;
 }
 
+.dial .dial-display .value-unit .unit {
+  font-size: 0.1em;
+  color: grey;
+  margin-left: 0.1em;
+  max-width: 30%;
+}
+
 .dial .dial-display .device {
+  position: absolute;
+  top: 7%;
   font-size: 0.07em;
   color: #ffa500;
-  height: 18%;
   animation: fadeInLoad 2s;
   line-height: 2em;
 }
 
 .dial .dial-display .info {
+  position: relative;
+  top: 28%;
   font-size: 0.06em;
   color: grey;
-  height: 16%;
   animation: fadeInLoad 2s;
+  line-height: 2em;
 }
 
 .dial .dial-display .info.nosetpoint {
   margin-bottom: 7px;
 }
 
-.dial .dial-display .setpoint {
+.dial .dial-display .extra {
+  position: relative;
+  top: 28%;
   font-size: 0.06em;
   color: grey;
-  height: 10%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 85%;
   animation: fadeInLoad 2s;
-  line-height: 0;
-  display: inline-block;
 }
 
-.dial .dial-display .setpoint .fas {
-  font-size: 1em !important;
+.dial .dial-display .extra div {
+  margin-left: 0.25em;
+  margin-right: 0.25em;
 }
 
-.dial .dial-display .setpoint.hidden {
+.dial .dial-display .extra div .data {
+  margin-left: -0.25em;
+}
+
+.dial .dial-display .extra div .unit {
+  font-size: 0.8em;
+  margin-left: -0.25em;
+  margin-right: 0.25em;
+}
+
+.dial .dial-display .extra .fas {
+  font-size: 0.8em !important;
+  margin: 0;
+}
+
+.dial .dial-display .extra img {
+  width: 1em;
+  margin-right: 0.25em;
+}
+
+.dial .dial-display .extra.hidden {
   visibility: hidden;
 }
 
-.dial:hover .dial-display .value {
-  font-size: 0.2em;
+.dial:hover .dial-display .value-unit .value {
+  font-size: 0.15em;
   color: orange;
   color: var(--dial-color);
 }
 
+.dial:hover .dial-display .value-unit .unit {
+  font-size: 0.05em;
+}
+
 .dial:hover .dial-display .info,
 .dial:hover .dial-display .device,
-.dial:hover .dial-display .setpoint {
+.dial:hover .dial-display .extra {
   display: none;
 }
 
@@ -3595,86 +3517,425 @@ td.agenda-title {
     opacity: 1;
   }
 }
+
+.dial-numbers {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  color: gray;
+}
+
+.dial-numbers span {
+  font-size: 0.06em;
+  width: 15%;
+  text-align: center;
+  position: absolute;
+}
+
+
+/* Dial face 360 degrees with 10 numbers */
+
+.dial-numbers .number.seg_360_10_0 {
+  transform: rotate(0.7rad);
+  left: 12%;
+  top: 78%;
+}
+
+.dial-numbers .number.seg_360_10_1 {
+  transform: rotate(7.7rad);
+  left: -2%;
+  top: 53%;
+}
+
+.dial-numbers .number.seg_360_10_2 {
+  transform: rotate(5.1rad);
+  left: 2%;
+  top: 27%;
+}
+
+.dial-numbers .number.seg_360_10_3 {
+  transform: rotate(5.62rad);
+  left: 18%;
+  top: 8%;
+}
+
+.dial-numbers .number.seg_360_10_4 {
+  transform: rotate(6.27rad);
+  left: 42%;
+  top: 0%;
+}
+
+.dial-numbers .number.seg_360_10_5 {
+  transform: rotate(7rad);
+  left: 67%;
+  top: 8%;
+}
+
+.dial-numbers .number.seg_360_10_6 {
+  transform: rotate(7.4rad);
+  left: 84%;
+  top: 27%;
+}
+
+.dial-numbers .number.seg_360_10_7 {
+  transform: rotate(4.95rad);
+  left: 88%;
+  top: 53%;
+}
+
+.dial-numbers .number.seg_360_10_8 {
+  transform: rotate(5.5rad);
+  left: 74%;
+  top: 78%;
+}
+
+.dial-numbers .number.seg_360_10_9 {
+  transform: rotate(6.28rad);
+  left: 42%;
+  top: 90%;
+}
+
+
+/* Dial face 360 degrees with 12 numbers */
+
+.dial-numbers .number.seg_360_12_0 {
+  transform: rotate(0.64rad);
+  left: 16.5%;
+  top: 81.5%;
+}
+
+.dial-numbers .number.seg_360_12_1 {
+  transform: rotate(7.4rad);
+  left: 2%;
+  top: 65%;
+}
+
+.dial-numbers .number.seg_360_12_2 {
+  transform: rotate(4.7rad);
+  left: -2.5%;
+  top: 45%;
+}
+
+.dial-numbers .number.seg_360_12_3 {
+  transform: rotate(5.25rad);
+  left: 4%;
+  top: 22%;
+}
+
+.dial-numbers .number.seg_360_12_4 {
+  transform: rotate(5.77rad);
+  left: 20.5%;
+  top: 6.4%;
+}
+
+.dial-numbers .number.seg_360_12_5 {
+  transform: rotate(6.26rad);
+  left: 42%;
+  top: 0.5%;
+}
+
+.dial-numbers .number.seg_360_12_6 {
+  transform: rotate(6.85rad);
+  left: 66%;
+  top: 7%;
+}
+
+.dial-numbers .number.seg_360_12_7 {
+  transform: rotate(7.3rad);
+  left: 80.7%;
+  top: 22%;
+}
+
+.dial-numbers .number.seg_360_12_8 {
+  transform: rotate(7.83rad);
+  left: 87%;
+  top: 44%;
+}
+
+.dial-numbers .number.seg_360_12_9 {
+  transform: rotate(5.17rad);
+  left: 83%;
+  top: 65%;
+}
+
+.dial-numbers .number.seg_360_12_10 {
+  transform: rotate(5.65rad);
+  left: 69%;
+  top: 81.5%;
+}
+
+.dial-numbers .number.seg_360_12_11 {
+  transform: rotate(6.28rad);
+  left: 42%;
+  top: 90%;
+}
+
+
+/* Dial face 280 degrees with 10 numbers */
+
+.dial-numbers .number.seg_280_11_0 {
+  transform: rotate(0.7rad);
+  left: 12%;
+  top: 78%;
+}
+
+.dial-numbers .number.seg_280_11_1 {
+  transform: rotate(7.5rad);
+  left: 1%;
+  top: 63%;
+}
+
+.dial-numbers .number.seg_280_11_2 {
+  transform: rotate(4.8rad);
+  left: -2.5%;
+  top: 42%;
+}
+
+.dial-numbers .number.seg_280_11_3 {
+  transform: rotate(5.3rad);
+  left: 5%;
+  top: 21%;
+}
+
+.dial-numbers .number.seg_280_11_4 {
+  transform: rotate(5.7rad);
+  left: 20%;
+  top: 6%;
+}
+
+.dial-numbers .number.seg_280_11_5 {
+  transform: rotate(6.27rad);
+  left: 42%;
+  top: 0%;
+}
+
+.dial-numbers .number.seg_280_11_6 {
+  transform: rotate(6.85rad);
+  left: 65%;
+  top: 6%;
+}
+
+.dial-numbers .number.seg_280_11_7 {
+  transform: rotate(7.27rad);
+  left: 80%;
+  top: 21%;
+}
+
+.dial-numbers .number.seg_280_11_8 {
+  transform: rotate(7.75rad);
+  left: 87.5%;
+  top: 42%;
+}
+
+.dial-numbers .number.seg_280_11_9 {
+  transform: rotate(5.15rad);
+  left: 84%;
+  top: 63%;
+}
+
+.dial-numbers .number.seg_280_11_10 {
+  transform: rotate(5.6rad);
+  left: 71.5%;
+  top: 80%;
+}
+
+.dial-switch {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 95%;
+  height: 95%;
+}
+
+.dial-switch input {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  filter: alpha(opacity=0);
+  -moz-opacity: 0;
+  opacity: 0;
+  z-index: 100;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  margin: 0;
+}
+
+.dial-switch .switch-face {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  border-radius: 50%;
+  background: #b2ac9e;
+  background: -moz-linear-gradient(#333333, #191919);
+  background: -ms-linear-gradient(#333333, #191919);
+  background: -o-linear-gradient(#333333, #191919);
+  background: -webkit-gradient(linear, 0 0, 0 100%, from(#333333), to(#191919));
+  background: -webkit-linear-gradient(#333333, #191919);
+  background: linear-gradient(#333333, #191919);
+  position: relative;
+  color: #a5a39d;
+  text-align: center;
+  -webkit-transition: all 0.2s ease-out;
+  -moz-transition: all 0.2s ease-out;
+  -ms-transition: all 0.2s ease-out;
+  -o-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  text-shadow: 0 2px 1px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 2px 3px rgba(255, 255, 255, 0.13), 0 5px 8px rgba(0, 0, 0, 0.3), 0 10px 10px 4px rgba(0, 0, 0, 0.3);
+  z-index: -1;
+  margin: 0;
+}
+
+.dial-switch .switch-face:after {
+  content: "";
+  position: absolute;
+  left: -20px;
+  right: -20px;
+  top: -20px;
+  bottom: -20px;
+  z-index: -2;
+  border-radius: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 10px rgba(0, 0, 0, 0.15);
+}
+
+.dial-switch .switch-face:before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  right: -10px;
+  top: -10px;
+  bottom: -10px;
+  z-index: -1;
+  border-radius: inherit;
+  box-shadow: inset 0 10px 10px rgba(0, 0, 0, 0.13);
+  -webkit-filter: blur(1px);
+  -moz-filter: blur(1px);
+  -ms-filter: blur(1px);
+  -o-filter: blur(1px);
+  filter: blur(1px);
+}
+
+.dial-switch .switch-face .device {
+  font-size: 12px;
+  font-size: 0.07em;
+  animation: fadeInLoad 2s;
+  position: absolute;
+  top: 25%;
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch .switch-face .info {
+  color: grey;
+  line-height: 2em;
+  font-size: 0.05em;
+  animation: fadeInLoad 2s;
+  position: absolute;
+  top: 60%;
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch input:checked {
+  width: 99%;
+  height: 99%;
+}
+
+.dial-switch input:checked~.switch-face {
+  box-shadow: 0 0 25px 1px var(--dial-rgba);
+  color: orange;
+  color: var(--dial-color);
+  width: 95%;
+  height: 95%;
+}
+
+.dial-switch .icon-off {
+  font-size: 0.1em;
+  color: #cccccc;
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch input:checked~.switch-face .device {
+  font-size: 0.06em;
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch input:checked~.switch-face .fas {
+  font-size: 0.08em;
+  color: orange;
+  color: var(--dial-color);
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch input:checked~.switch-face .info {
+  font-size: 0.04em;
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+.dial-switch .icon-off:after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 70%;
+  height: 70%;
+  left: 50%;
+  top: 50%;
+  z-index: -1;
+  margin: -35% 0 0 -35%;
+  border-radius: 50%;
+  background: #d2cbc3;
+  background: -moz-linear-gradient(#161616, #6c6c6c);
+  background: -ms-linear-gradient(#161616, #6c6c6c);
+  background: -o-linear-gradient(#161616, #6c6c6c);
+  background: -webkit-gradient(linear, 0 0, 0 100%, from(#161616), to(#6c6c6c));
+  background: -webkit-linear-gradient(#161616, #6c6c6c);
+  background: linear-gradient(#161616, #6c6c6c);
+  box-shadow: 0 -2px 5px rgba(255, 255, 255, 0.05), 0 2px 5px rgba(255, 255, 255, 0.1);
+  -webkit-transition: all 0.1s ease;
+  -moz-transition: all 0.1s ease;
+  -ms-transition: all 0.1s ease;
+  -o-transition: all 0.1s ease;
+  transition: all 0.1s ease;
+}
+
+
 /* END: DIAL */
 
+
 /* Traffic */
+
 #trafficweb iframe {
   width: 100%;
   height: 575px
 }
-
-/* start colorPicker */
-
-.colorpicker {
-/*
-  color: black;
-  max-width: 90%;
-  min-width: unset;
-  width: 100%;*/
-}
-
-.colorpicker .modal-header {
-  display: flex
-}
-
-.colorpicker .modal-title {
-  width: 100%
-}
-.colorpicker .modal-dialog {
-  max-width: 90%;
-  min-width: unset;
-  width: 90%;
-}
-
-/*
-.colorpicker .modal-content {
-  max-width: 90%;
-  min-width: unset;
-  width: 50%;
-}*/
-
-.colorpicker .cp-iro {
-  overflow-x: auto;
-  flex-wrap: wrap
-}
-
-.colorpicker .cp-buttons {
-  margin-bottom: 10px;
-}
-
-.colorpicker .cp-buttonsOnOff{
-  background-color: rgba(0,0,0,0.2);
-}
-
-.colorpicker .cp-buttonsOnOff .btn {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  color: darkgrey;
-  background-color:lightgray
-/*  margin-top: 10px;
-  margin-bottom: 10px;*/
-  /*width: 48px;*/
-}
-
-.colorpicker .cp-buttonsOnOff .btn.active {
-/*  background-color: rgba(0,0,0,0.4)*/
-  border-style: solid;
-  border-color: black;
-  border-width: medium;
-  background-color:gray;
-  color: white;
-  /*width: 48px;*/
-}
-
-
-.cp-iro {
-  display: inline-flex;
-  align-items: center;
-}
-
-.cp-iro>div {
-  margin: 0 10px
-}
-
-
-/*end colorpicker*/

--- a/js/components/dial.js
+++ b/js/components/dial.js
@@ -1,4 +1,4 @@
-/* global settings Domoticz Dashticz moment _TEMP_SYMBOL*/
+/* global settings Domoticz Dashticz moment _TEMP_SYMBOL CircleType*/
 var DT_dial = {
   name: 'dial',
 
@@ -7,117 +7,155 @@ var DT_dial = {
    * @param {object} block  User specified block config.
    * @param {string} key    identifier used for block selection.
    */
-  canHandle: function (block, key) {
+  canHandle: function(block, key) {
     return block && block.type === 'dial';
   },
 
   /**
    * Called at initiation returning a jquery deferred.
    */
-  init: function () {
+  init: function() {
     this.debug = false;
     this.isTouch = false;
     this.active = false;
     this.center = { x: 0, y: 0 };
     this.R2D = 180 / Math.PI;
-    this.timeformat = isDefined(settings['timeformat'])
-      ? settings['timeformat']
-      : 'HH:mm, DD/MM/YY';
+    this.timeformat = isDefined(settings['timeformat']) ?
+      settings['timeformat'] :
+      'HH:mm, DD/MM/YY';
+    this.settings = false;
 
     document.addEventListener(
       'touchstart',
-      function () {
+      function() {
         DT_dial.isTouch = true;
-      },
-      { passive: false }
+      }, { passive: false }
     );
   },
   defaultCfg: {
     title: false,
     width: 3,
     last_update: true,
-    dialicon: 'fas fa-calendar-alt',
     dialimage: false,
     flash: 0,
     showring: false,
+    showunit: false,
+    shownumbers: false,
+    offset: 0,
   },
 
   /**
    * Called once the component has been intialised and mounted in DOM.
    * @param {object} me  Core component object.
    */
-  run: function (me) {
+  run: function(me) {
     me.idx = isDefined(me.block.idx) ? me.block.idx : me.key;
     me.block.idx = me.idx; /* required for existing functions */
     me.id = 'dial_' + me.idx;
-    me.height = isDefined(me.block.height)
-      ? parseInt(me.block.height)
-      : parseInt($(me.mountPoint + ' div').css('width'));
+    me.height = isDefined(me.block.height) ?
+      parseInt(me.block.height) :
+      parseInt($(me.mountPoint + ' div').css('width'));
     me.fontsize = 0.8 * me.height;
     me.dialRange = 280;
     me.active = true;
     DT_dial.color(me);
+    me.segments = 11;
 
-    Domoticz.subscribe(me.idx, true, function (device) {
-      me.device = device;
-      me.isSetpoint = isDefined(me.device.SetPoint);
-      me.lastupdate = me.block.last_update
-        ? moment(me.device.LastUpdate).format(DT_dial.timeformat)
-        : false;
-      DT_dial.make(me);
-    });
+    /* Get Domoticz setting then make */
+    Domoticz.request('type=settings')
+      .then(function(res) {
+        if (res) {
+          DT_dial.settings = res;
+        }
+      })
+      .then(function() {
+        Domoticz.subscribe(me.idx, true, function(device) {
+          me.device = device;
+          me.isSetpoint = isDefined(me.device.SetPoint);
+          me.lastupdate = !me.block.last_update ?
+            false :
+            moment(me.device.LastUpdate).format(DT_dial.timeformat);
+          me.info = [];
+          DT_dial.make(me);
+        });
+      });
   },
 
   /**
    * Creates or updates the dial and applies current values.
    * @param {object} me  Core component object.
    */
-  make: function (me) {
+  make: function(me) {
     DT_dial.resize(me);
+    var d = me.device;
 
-    if (
-      me.device.Type === 'Heating' ||
-      me.device.Type === 'Thermostat' ||
-      me.device.SubType === 'SetPoint'
-    ) {
-      DT_dial.heating(me);
-    }
-    if (
-      me.device.SubType === 'Evohome' ||
-      me.device.SwitchType === 'Selector'
-    ) {
-      DT_dial.control(me);
-    }
-    if (me.device.SwitchType === 'Dimmer') {
-      DT_dial.dimmer(me);
+    switch (true) {
+      case d.SubType === 'Evohome':
+      case d.SwitchType === 'Selector':
+        DT_dial.control(me);
+        break;
+      case d.Type === 'Heating':
+      case d.Type === 'Thermostat':
+      case d.SubType === 'SetPoint':
+        DT_dial.heating(me);
+        break;
+      case d.SwitchType === 'Dimmer':
+        DT_dial.dimmer(me);
+        break;
+      case d.SwitchType === 'On/Off':
+        DT_dial.onoff(me);
+        break;
+      case d.Type === 'Temp + Humidity':
+      case d.Type === 'Temp + Humidity + Baro':
+        DT_dial.temperature(me);
+        break;
+      case d.Type === 'Wind':
+        DT_dial.wind(me);
+        break;
+      case d.Type === 'P1 Smart Meter':
+        DT_dial.p1smartmeter(me);
+        break;
     }
 
-    templateEngine.load('dial').then(function (template) {
+    if (me.block.shownumbers && me.numbers == undefined) {
+      me.numbers = DT_dial.numbers(me);
+    }
+
+    templateEngine.load('dial').then(function(template) {
       var dataObject = {
         id: me.id,
         size: me.size,
         name: me.block.title ? me.block.title : me.device.Name,
         min: me.min,
         max: me.max,
+        showunit: me.block.showunit,
         type: me.device.Type,
         value: me.value,
-        hasSetpoint: me.isSetpoint,
+        hasSetpoint: me.isSetpoint || me.subdevice,
         setpoint: me.setpoint,
         until: me.until,
         status: me.status,
         override: me.override,
         on: me.demand ? 'on' : 'off',
-        controller: me.type === 'evo' || me.type === 'selector',
+        controller: me.controller,
+        fixed: me.fixed,
+        onoff: me.onoff,
         options: me.options,
-        unit: _TEMP_SYMBOL,
+        unitvalue: me.unitvalue,
+        info: me.info,
         lastupdate: me.lastupdate,
         color: me.color,
         rgba: me.rgba,
         fontsize: me.fontsize,
         needleL: me.height / 2,
         needleW: me.height / 17,
-        icon: me.block.dialicon,
+        icon: me.dialicon,
         image: me.block.dialimage,
+        numbers: me.numbers,
+        range: me.dialRange,
+        class: me.class,
+        split: me.splitdial,
+        slice: me.slice,
       };
 
       /* Mount dial */
@@ -126,7 +164,7 @@ var DT_dial = {
       $mount.addClass('swiper-no-swiping');
       $(me.mountPoint + ' .dt_block').css('height', me.height + 'px');
       if (me.type === 'evo' || me.type === 'selector') {
-        $(me.select + ' li').each(function (index) {
+        $(me.select + ' li').each(function(index) {
           if ($(this).data('val') === me.status) {
             $(this).addClass('selected');
           }
@@ -138,7 +176,7 @@ var DT_dial = {
         $(me.mountPoint + ' .dial')
           .addClass('dial-flash')
           .delay(me.block.flash)
-          .queue(function () {
+          .queue(function() {
             $(this).removeClass('dial-flash').dequeue();
           });
       }
@@ -146,20 +184,23 @@ var DT_dial = {
       /* Always show color outer ring if required */
       if (me.block.showring) {
         $(me.mountPoint + ' .dial .bar').addClass('show-ring');
+        $(me.mountPoint + ' .dial .fill').addClass('show-ring');
       }
 
-      /* Add dial calculations */
-      me.body = $(me.mountPoint + ' .dt_content .dial');
-      me.min = me.body.data('min');
-      me.max = me.body.data('max');
-      me.scale = me.dialRange / (me.max - me.min);
-      me.value = me.body.data('value');
-      me.angle = DT_dial.degrees(me);
-      me.control = me.body.find('.dial-needle');
-
       DT_dial.tap(me);
-      DT_dial.listen(me);
-      DT_dial.rotate(me);
+
+      /* Add dial calculations */
+      if (!me.onoff && !me.controller) {
+        me.body = $(me.mountPoint + ' .dt_content .dial');
+        me.min = me.body.data('min');
+        me.max = me.body.data('max');
+        me.scale = me.dialRange / (me.max - me.min);
+        me.value = me.body.data('value');
+        me.angle = DT_dial.degrees(me);
+        me.control = me.body.find('.dial-needle');
+        DT_dial.listen(me);
+        DT_dial.rotate(me);
+      }
     });
   },
 
@@ -167,11 +208,11 @@ var DT_dial = {
    * Provides interaction with the dial via tap.
    * @param {object} me  Core component object.
    */
-  tap: function (me) {
+  tap: function(me) {
     var d = document.getElementById(me.id);
     var mc = new Hammer(d);
 
-    mc.on('tap', function (ev) {
+    mc.on('tap', function(ev) {
       if (me.status === 'TemporaryOverride') {
         me.override = false;
         me.demand = false;
@@ -206,24 +247,24 @@ var DT_dial = {
    * Listen for all dial needle rotation by the user.
    * @param {object} me  Core component object.
    */
-  listen: function (me) {
+  listen: function(me) {
     if (me.active) {
-      ['mousedown', 'touchstart'].forEach(function (e) {
+      ['mousedown', 'touchstart'].forEach(function(e) {
         me.control[0].addEventListener(e, DT_dial.start, { passive: false });
       });
       me.body
-        .bind('mousedown touchstart', function (event) {
+        .bind('mousedown touchstart', function(event) {
           Domoticz.hold(me.idx);
         })
-        .bind('mousemove touchmove', function (event) {
+        .bind('mousemove touchmove', function(event) {
           if (DT_dial.active) {
-            DT_dial.isTouch && event.targetTouches
-              ? DT_dial.angle(me, event.targetTouches[0])
-              : DT_dial.angle(me, event);
+            DT_dial.isTouch && event.targetTouches ?
+              DT_dial.angle(me, event.targetTouches[0]) :
+              DT_dial.angle(me, event);
           }
           return false;
         })
-        .bind('mouseup touchend mouseleave', function (event) {
+        .bind('mouseup touchend mouseleave', function(event) {
           if (DT_dial.active) DT_dial.stop(me);
         });
     }
@@ -233,7 +274,7 @@ var DT_dial = {
    * Start of dial needle rotation, set active.
    * @param {object} e  The touch or mouse event.
    */
-  start: function (e) {
+  start: function(e) {
     var bb = this.getBoundingClientRect();
     DT_dial.center = {
       x: bb.left + bb.width / 2,
@@ -247,15 +288,15 @@ var DT_dial = {
    * @param {object} me  Core component object.
    * @param {object} e   The touch or mouse event.
    */
-  angle: function (me, e) {
+  angle: function(me, e) {
     var x =
-      DT_dial.isTouch && e.touches && e.touches.length
-        ? e.touches[0].clientX - DT_dial.center.x
-        : e.clientX - DT_dial.center.x;
+      DT_dial.isTouch && e.touches && e.touches.length ?
+      e.touches[0].clientX - DT_dial.center.x :
+      e.clientX - DT_dial.center.x;
     var y =
-      DT_dial.isTouch && e.touches && e.touches.length
-        ? e.touches[0].clientY - DT_dial.center.x
-        : e.clientY - DT_dial.center.y;
+      DT_dial.isTouch && e.touches && e.touches.length ?
+      e.touches[0].clientY - DT_dial.center.x :
+      e.clientY - DT_dial.center.y;
     me.angle = DT_dial.R2D * Math.atan2(y, x);
     DT_dial.rotate(me);
   },
@@ -264,36 +305,54 @@ var DT_dial = {
    * Apply rotation and styling, updating value.
    * @param {object} me  Core component object.
    */
-  rotate: function (me) {
+  rotate: function(me) {
     var $d = $(me.body);
     var a = me.angle;
 
     if ((a >= -180 && a <= 60) || (a >= 140 && a <= 180)) {
       /* within valid range */
 
-      me.degrees = a >= 140 && a <= 180 ? a - 140 : a + 220;
+      me.degrees = me.unlimited ?
+        a + me.block.offset :
+        a >= 140 && a <= 180 ?
+        a - 140 :
+        a + 220;
 
-      if (a >= -40 && a <= 60) {
-        /* right side, e.g. blue */
+      var val = me.value;
 
-        $d.toggleClass('p180', true).removeClass('p0');
-        $d.find('.bar').css({ webkitTransform: 'rotate(180deg)' });
-        $d.find('.fill').css({
-          webkitTransform: 'rotate(' + me.degrees + 'deg)',
-        });
-      } else if ((a >= 140 && a <= 180) || (a >= -180 && a <= -40)) {
-        /* left side, e.g. orange */
-
+      if (me.unlimited) {
+        /* For dials such as Wind which rotate 360 */
+        val = me.temp;
+        $d.addClass('p360');
+      } else if (me.splitdial) {
+        /* For dials such as P1 Smart Meter which split left/right at 12 o'clock */
         $d.toggleClass('p0', true).removeClass('p180');
         $d.find('.bar').css({
-          webkitTransform: 'rotate(' + me.degrees + 'deg)',
+          webkitTransform: 'rotate(' + (me.degrees + 220) + 'deg)',
         });
+      } else {
+        /* For tradditional dials that start at 7 o'clock */
+        if (a >= -40 && a <= 60) {
+          /* right side, e.g. blue */
+          $d.toggleClass('p180', true).removeClass('p0');
+          $d.find('.bar').css({ webkitTransform: 'rotate(180deg)' });
+          $d.find('.fill').css({
+            webkitTransform: 'rotate(' + me.degrees + 'deg)',
+          });
+        } else if ((a >= 140 && a <= 180) || (a >= -180 && a <= -40)) {
+          /* left side, e.g. orange */
+          $d.toggleClass('p0', true).removeClass('p180');
+          $d.find('.bar').css({
+            webkitTransform: 'rotate(' + me.degrees + 'deg)',
+          });
+        }
+
+        if (me.active)
+          me.value = Math.round((me.min + me.degrees / me.scale) * 10) / 10;
       }
 
-      me.value = Math.round(me.min + me.degrees / me.scale);
-
       if (me.isSetpoint) {
-        if (me.value >= me.setpoint) {
+        if (val >= me.setpoint) {
           /* at or above setpoint */
 
           $d.find('.bar').addClass('primary').removeClass('secondary');
@@ -306,11 +365,16 @@ var DT_dial = {
         }
       }
 
-      $d.find('.value').text(me.value).data('value', me.value);
+      var valueformat =
+        me.value % 1 === 0 ? me.value : number_format(me.value, 1);
+
+      $d.find('.value').text(valueformat).data('value', me.value);
       $d.find('.info').text($d.data('info'));
       $(me.control).css({
         webkitTransform: 'rotate(' + (-140 + me.degrees) + 'deg)',
       });
+    } else {
+      console.log(me.block.title + ': angle outside permitted range = ' + a);
     }
   },
 
@@ -318,9 +382,9 @@ var DT_dial = {
    * Calculate degrees based on device range.
    * @param {object} me  Core component object.
    */
-  degrees: function (me) {
+  degrees: function(me) {
     var deg = me.value * me.scale;
-    deg = deg > 40 ? (deg += -220) : (deg += 140);
+    deg += me.splitdial || deg > 40 ? -220 : 140;
     return deg - me.min * me.scale;
   },
 
@@ -328,7 +392,7 @@ var DT_dial = {
    * Rotation has stopped, update the device.
    * @param {object} me  Core component object.
    */
-  stop: function (me) {
+  stop: function(me) {
     Domoticz.release(me.idx);
     switch (me.type) {
       case 'zone':
@@ -348,7 +412,7 @@ var DT_dial = {
    * Update device with new values post rotation.
    * @param {object} me  Core component object.
    */
-  update: function (me) {
+  update: function(me) {
     switch (me.type) {
       case 'zone':
         switchEvoZone(me, me.setpoint, me.override);
@@ -366,21 +430,21 @@ var DT_dial = {
    * Create RGB and RBGA values for styling if block.color exists.
    * @param {object} me  Core component object.
    */
-  color: function (me) {
+  color: function(me) {
     if (isDefined(me.block.color)) {
       var c = $(me.mountPoint)
         .css('color', me.block.color)
         .css('color'); /* change all formats to rgb */
       me.color = c;
       me.rgba =
-        c.split(',').length === 4
-          ? c.replace(
-              c.split(',')[3],
-              '0.5)'
-            ) /* already rgba, make 50% opaque */
-          : c
-              .replace(')', ', 0.5)')
-              .replace('rgb', 'rgba'); /* convert rgb to rgba at 50% opaque*/
+        c.split(',').length === 4 ?
+        c.replace(
+          c.split(',')[3],
+          '0.5)'
+        ) /* already rgba, make 50% opaque */ :
+        c
+        .replace(')', ', 0.5)')
+        .replace('rgb', 'rgba'); /* convert rgb to rgba at 50% opaque*/
     } else {
       me.color = 'rgb(255, 165, 0)';
       me.rgba = 'rgba(255, 165, 0, 0.5)';
@@ -392,10 +456,10 @@ var DT_dial = {
    * Ensure all dials are responsive based on column width on screen resize.
    * @param {object} me  Core component object.
    */
-  resize: function (me) {
+  resize: function(me) {
     window.addEventListener(
       'resize',
-      function () {
+      function() {
         DT_dial.run(me);
       },
       true
@@ -403,48 +467,93 @@ var DT_dial = {
   },
 
   /**
+   * Displays the icon or image for the dial info.
+   * @param {object} param    String or object from block config.
+   * @param {number} index    Index of array if param is object.
+   * @param {object} length   Length of array expected.
+   * @param {object} fallback Default value to use if no block config.
+   */
+  display: function(param, index, length, fallback) {
+    return isDefined(param) ?
+      isObject(param) && param.length === length ?
+      param[index] :
+      param :
+      fallback;
+  },
+
+  /**
    * Configures the data for Evohome zones/hot water and thermostats.
    * @param {object} me  Core component object.
    */
-  heating: function (me) {
+  heating: function(me) {
     me.type = me.device.Type === 'Heating' ? 'zone' : 'stat';
-    me.min = isDefined(settings['setpoint_min']) ? settings['setpoint_min'] : 5;
-    me.max = isDefined(settings['setpoint_max'])
-      ? settings['setpoint_max']
-      : 35;
+    me.unitvalue = _TEMP_SYMBOL;
+    me.min = isDefined(settings['setpoint_min']) ?
+      settings['setpoint_min'] :
+      isDefined(me.block.min) ?
+      me.block.min :
+      5;
+    me.max = isDefined(settings['setpoint_max']) ?
+      settings['setpoint_max'] :
+      isDefined(me.block.max) ?
+      me.block.max :
+      35;
 
+    me.dialicon = DT_dial.display(
+      me.block.dialicon,
+      0,
+      1,
+      'fas fa-calendar-alt'
+    );
+    me.dialimage = DT_dial.display(me.block.dialimage, 0, 1, false);
+
+    /* EvoHome Zones */
     if (me.type === 'zone') {
       me.value = me.device.Temp;
       me.setpoint = me.isSetpoint ? me.device.SetPoint : 20;
-      me.boost = isDefined(settings['evohome_boost_zone'])
-        ? settings['evohome_boost_zone']
-        : 60;
+      me.boost = isDefined(settings['evohome_boost_zone']) ?
+        settings['evohome_boost_zone'] :
+        60;
       me.until = isDefined(me.device.Until) ? me.device.Until : false;
       me.status = isDefined(me.device.Status) ? me.device.Status : 'Auto';
       me.override = me.status === 'TemporaryOverride';
       me.demand = me.status !== 'HeatingOff' && me.value < me.setpoint;
       me.lastupdate =
-        me.lastupdate && me.until
-          ? moment(me.until).format(DT_dial.timeformat)
-          : me.lastupdate;
+        me.lastupdate && me.until ?
+        moment(me.until).format(DT_dial.timeformat) :
+        me.lastupdate;
 
+      /* EvoHome Hot water */
       if (me.device.SubType === 'Hot Water') {
         me.active = false;
         me.type = 'dhw';
         me.state = me.device.State;
-        me.min = 20;
-        me.max = 60;
+        me.min = isDefined(me.block.min) ? me.block.min : 20;
+        me.max = isDefined(me.block.min) ? me.block.min : 60;
         me.setpoint = 40;
         me.demand = me.device.State === 'On';
-        me.boost = isDefined(settings['evohome_boost_hw'])
-          ? settings['evohome_boost_hw']
-          : 30;
+        me.boost = isDefined(settings['evohome_boost_hw']) ?
+          settings['evohome_boost_hw'] :
+          30;
       }
+      me.info.push({
+        icon: me.override ? 'fas fa-stopwatch small_fa' : me.dialicon,
+        image: me.override ? 'fas fa-stopwatch small_fa' : me.block.dialimage,
+        data: me.setpoint,
+        unit: _TEMP_SYMBOL,
+      });
     } else {
+      /* Combining Toon Thermostat with Toon Temp device */
       if (isDefined(me.block.temp)) {
         me.value = Domoticz.getAllDevices()[me.block.temp].Temp;
         me.isSetpoint = true;
         me.setpoint = me.device.SetPoint;
+        me.info.push({
+          icon: 'fas fa-calendar-alt',
+          data: me.setpoint,
+          unit: _TEMP_SYMBOL,
+        });
+        /* Standard thermostat device */
       } else {
         me.value = number_format(me.device.Data, 1);
         me.isSetpoint = false;
@@ -454,10 +563,91 @@ var DT_dial = {
   },
 
   /**
+   * Configures the data for read only temperature devices.
+   * @param {object} me  Core component object.
+   */
+  temperature: function(me) {
+    me.type = 'temp';
+    me.active = false;
+    me.min = isDefined(me.block.min) ? me.block.min : 5;
+    me.max = isDefined(me.block.max) ? me.block.max : 35;
+    me.value = me.device.Temp;
+    me.isSetpoint = true;
+    me.setpoint = isDefined(me.block.setpoint) ? me.block.setpoint : 20;
+    me.unitvalue = _TEMP_SYMBOL;
+
+    me.info.push({
+      icon: DT_dial.display(me.block.dialicon, 0, 2, 'fas fa-tint'),
+      image: DT_dial.display(me.block.dialimage, 0, 2, false),
+      data: parseFloat(me.device.Data.split(',')[1]),
+      unit: '%',
+    });
+
+    if (me.device.Type === 'Temp + Humidity + Baro') {
+      me.info.push({
+        icon: DT_dial.display(me.block.dialicon, 1, 2, 'fas fa-cloud'),
+        image: DT_dial.display(me.block.dialimage, 1, 2, false),
+        data: parseFloat(me.device.Data.split(',')[2]),
+        unit: 'hPa',
+      });
+    }
+    return;
+  },
+
+  wind: function(me) {
+    me.type = 'wind';
+    me.active = false;
+    me.unlimited = true;
+    me.min = 0;
+    me.max = 360;
+    me.dialRange = 360;
+    me.value = me.device.Direction;
+    me.unitvalue = '°';
+    me.segments = 12;
+    me.numbers = [210, 240, 270, 300, 330, 0, 30, 60, 90, 120, 150, 180];
+    me.subdevice = true;
+    me.setpoint = isDefined(me.block.setpoint) ? me.block.setpoint : 15;
+    me.isSetpoint = true;
+    me.temp = me.device.Temp;
+
+    var windUnit = 'm/s';
+    if (DT_dial.settings) {
+      var wind = ['m/s', 'km/h', 'mph', 'Knts', 'Bfrt'];
+      windUnit = wind[DT_dial.settings.WindUnit];
+    }
+
+    me.info.push({
+      icon: DT_dial.display(me.block.dialicon, 0, 3, 'fas fa-location-arrow'),
+      image: DT_dial.display(me.block.dialimage, 0, 3, false),
+      data: me.device.DirectionStr,
+      unit: '',
+    }, {
+      icon: DT_dial.display(me.block.dialicon, 1, 3, 'fas fa-wind'),
+      image: DT_dial.display(me.block.dialimage, 1, 3, false),
+      data: me.device.Speed,
+      unit: windUnit,
+    }, {
+      icon: DT_dial.display(
+        me.block.dialicon,
+        2,
+        3,
+        'fas fa-thermometer-half'
+      ),
+      image: DT_dial.display(me.block.dialimage, 0, 3, false),
+      data: me.device.Temp,
+      unit: _TEMP_SYMBOL,
+    });
+    return;
+  },
+
+  /**
    * Configures the data for Evohome controllers.
    * @param {object} me  Core component object.
    */
-  control: function (me) {
+  control: function(me) {
+    me.select = '#' + me.id + ' .status';
+    me.controller = true;
+    me.fixed = true;
     if (me.device.SubType === 'Evohome') {
       me.type = 'evo';
       me.status = me.device.Status;
@@ -474,34 +664,96 @@ var DT_dial = {
       me.status = me.device.Level;
       me.options = [];
       var levelNames = atob(me.device.LevelNames).split('|');
-      $.each(levelNames, function (index, value) {
+      $.each(levelNames, function(index, value) {
         me.options.push({ val: index * 10, text: value });
       });
     }
-    me.select = '#' + me.id + ' .status';
+    return;
   },
 
   /**
    * Configures the data for devices of dimmer switchtype.
    * @param {object} me  Core component object.
    */
-  dimmer: function (me) {
+  dimmer: function(me) {
     me.type = 'dim';
-    me.min = 0;
-    me.max = 100;
+    me.min = isDefined(me.block.min) ? me.block.min : 0;
+    me.max = isDefined(me.block.max) ? me.block.max : 100;
     me.value =
-      me.device.Data === 'Off'
-        ? 0
-        : me.device.Level > me.max * 0.95
-        ? me.max
-        : me.device.Level < me.max * 0.05
-        ? me.min
-        : me.device.Level;
+      me.device.Data === 'Off' ?
+      0 :
+      me.device.Level > me.max * 0.95 ?
+      me.max :
+      me.device.Level < me.max * 0.05 ?
+      me.min :
+      me.device.Level;
     me.demand = me.value > 0;
-    me.maxdim = isDefined(me.device.MaxDimLevel)
-      ? parseInt(me.device.MaxDimLevel)
-      : 100;
+    me.maxdim = isDefined(me.device.MaxDimLevel) ?
+      parseInt(me.device.MaxDimLevel) :
+      100;
+    me.segments = 11;
     return;
+  },
+
+  /**
+   * Configures the data for devices of on/off switchtype.
+   * @param {object} me  Core component object.
+   */
+  onoff: function(me) {
+    me.type = 'onoff';
+    me.fixed = true;
+    me.onoff = true;
+    return;
+  },
+
+  /**
+   * Configures the data for devices of P1 Smart Meter type.
+   * @param {object} me  Core component object.
+   */
+  p1smartmeter: function(me) {
+    me.type = 'p1';
+    me.active = false;
+    me.min = isDefined(me.block.min) ? me.block.min : -10;
+    me.max = isDefined(me.block.max) ? me.block.max : 10;
+    me.value =
+      Math.round(
+        (parseFloat(me.device.CounterDelivToday) -
+          parseFloat(me.device.CounterToday)) *
+        100
+      ) / 100;
+    me.class = me.value > 0 ? 'positive' : 'negative';
+    me.slice = me.value > 0 ? 'splitdial-plus' : 'splitdial-minus';
+    me.unitvalue = 'kWh';
+    me.subdevice = true;
+    me.splitdial = true;
+
+    me.info.push({
+      icon: DT_dial.display(me.block.dialicon, 0, 2, 'fas fa-sun'),
+      image: DT_dial.display(me.block.dialimage, 0, 2, false),
+      data: me.device.CounterDelivToday,
+      unit: '',
+    }, {
+      icon: DT_dial.display(me.block.dialicon, 1, 2, 'fas fa-bolt'),
+      image: DT_dial.display(me.block.dialimage, 1, 2, false),
+      data: me.device.CounterToday,
+      unit: '',
+    });
+    return;
+  },
+
+  /**
+   * Create the numbers for the dial face.
+   * @param {object} me  Core component object.
+   */
+  numbers: function(me) {
+    var x = me.min;
+    var numbers = [];
+    me.increment = (me.max - me.min) / (me.segments - 1);
+    for (var i = 0; i < me.segments; i++) {
+      numbers.push(Math.ceil(x));
+      x += me.increment;
+    }
+    return numbers;
   },
 };
 Dashticz.register(DT_dial);

--- a/tpl/dial.tpl
+++ b/tpl/dial.tpl
@@ -1,18 +1,26 @@
-<div id="" class="dial {{size}} {{#if controller}}fixed{{/if}}" data-device="{{name}}" data-min="{{min}}" data-max="{{max}}"
+<div class="dial {{size}} {{#if fixed}}fixed{{/if}}" data-device="{{name}}" data-min="{{min}}" data-max="{{max}}"
     data-type="{{type}}" data-value="{{value}}" data-setpoint="{{setpoint}}" data-status="{{status}}" 
     data-until="{{until}}" data-unit="{{unit}}" data-info="{{lastupdate}}" style="font-size: {{fontsize}}px;--dial-color: {{rgba}};">
-    <div class="slice">
-        <div class="bar primary" style="--dial-color:{{color}};"></div>
-        <div class="fill primary" style="--dial-color:{{color}};"></div>
+    <div class="slice {{#if split}}{{slice}}{{/if}}">
+        <div class="bar primary {{class}}" style="--dial-color:{{color}};"></div>
+        <div class="fill primary {{class}}" style="--dial-color:{{color}};"></div>
     </div>
-    <div class="dial-container">
-        <div class="dial-face"></div>
-        {{#unless controller}}
+    <div class="dial-container">         
+        <div id="face{{id}}" class="dial-face">
+            <div class="dial-numbers">
+                {{#if numbers}}       
+                {{#each numbers as |number|}}
+                <span class="number seg_{{../range}}_{{../numbers.length}}_{{@index}}">{{number}}</span>
+                {{/each}}
+                {{/if}}
+            </div>
+        </div>        
+        {{#unless fixed}}
         <div class="draggable">
             <div class="dial-needle" style="--dial-color: {{color}};--needle-length: {{needleL}}px;--needle-width: {{needleW}}px;"></div>
         </div>
         {{/unless}}
-        <div id="{{id}}" class="dial-center {{on}}" style="--dial-rgba: {{rgba}};">
+        <div id="{{id}}" class="dial-center {{on}}" style="--dial-rgba: {{rgba}};{{#if onoff}}background: transparent; box-shadow: none;{{/if}}">
             {{#if controller}}
             <div class="dial-menu">   
                 <ul class="status" style="--dial-color: {{color}};">
@@ -21,26 +29,43 @@
                     {{/each}}
                 </ul>  
             </div>
+            {{else if onoff}}
+            <div class="dial-switch">   
+                <input type="checkbox">
+                <div class="switch-face">
+                    <div class="device" style="color:{{color}}">{{name}}</div>
+                    <i class="fas fa-power-off icon-off" style=""color:{{color}}"></i>
+                    {{#if lastupdate}} 
+                    <span class="info nosetpoint">{{lastupdate}}</span>
+                    {{/if}}
+                </div>
+            </div>
             {{else}}
             <div class="dial-display">
                 <span class="device" style="color:{{color}};">{{name}}</span>
-                <span class="value" style="--dial-color: {{color}};">{{value}}</span>
+                <div class="value-unit">
+                    <span class="value" style="--dial-color: {{color}};">{{value}}</span>
+                    {{#if showunit}}
+                    <span class="unit" style="--dial-color: {{color}};">{{unitvalue}}</span>
+                    {{/if}}
+                </div>
                 {{#if lastupdate}} 
                 <span class="info {{#unless hasSetpoint}}nosetpoint{{/unless}}">{{lastupdate}}</span>
                 {{/if}}
                 {{#if hasSetpoint}}
-                <span class="setpoint vertical-center">
-                    {{#if override}}                    
-                    <i class="fas fa-stopwatch small_fa">&nbsp;</i>
-                    {{else}}
-                        {{#unless image}}
-                        <i class="{{icon}}">&nbsp;</i>
+                <div class="extra">
+                    {{#each info}}
+                    <div>
+                        {{#unless this.image}}
+                        <i class="{{this.icon}}">&nbsp;</i>
                         {{else}}
-                        <img src="img/{{image}}" style="width:15%;">
-                        {{/unless}}
-                    {{/if}}
-                    <span>{{setpoint}}{{unit}}</span>
-                </span>
+                        <img src="img/{{this.image}}">
+                        {{/unless}}                    
+                        <span class="data">{{this.data}}</span>
+                        <span class="unit">{{this.unit}}</span>
+                    </div>
+                    {{/each}}             
+                </div>
                 {{/if}}
             </div>
             {{/if}}


### PR DESCRIPTION
**New devices supported:** 

1. SwitchType = 'On/Off'
2. Type = 'Temp + Humidity'
3. Type = 'Temp + Humidity + Baro'
4. Type = 'Wind'
5. Type = 'P1 Smart Meter'

**SwitchType = 'On/Off'** - any devices with this switchtype and type: 'dial' will automatically render as a dial button.
```
blocks['kitchen_lights'] = {
  idx: 451,
  title: 'Kitchen',
  type: 'dial',
  color: '#57c4d6',
  width: 2
}
```
![image](https://user-images.githubusercontent.com/33834551/87257728-4bda7280-c495-11ea-8e2c-39f72d658b93.png)

**Type = 'Temp + Humidity'**  - will display temperature as the main value and humidity as extra info below. There is enough room to display last_update with this dial.

```
blocks['temp_hum'] = {
  idx: 435,
  title: 'Weather 1',
  type: 'dial', 
  setpoint: 15,  // this value will be used to control the color of the outer ring, e.g. < 15 is blue, >= 15 is orange
  min: -10, // set the minimum value for the dial range (default is 5)
  max: 40, // set the maximum value for the dial range (default is 35)
  width: 2,
  shownumbers: true,  // display the numbers on the dial (default is false)
  showring: true, // display outer ring color all the time (default is false, will only display when hover over)
  showunit: true // display unit for the dial value (default is false)
}
```
![image](https://user-images.githubusercontent.com/33834551/87257830-50535b00-c496-11ea-84ee-149b6a61e740.png)

**Type = 'Temp + Humidity + Baro'** - similar to above, but with Baro as extra info too. Last_update can be added but it is a tight fit.
```
blocks['temp_hum_baro'] = {
  idx: 72,
  title: 'Weather 2',
  type: 'dial',
  setpoint: 15,
  min: -10,
  max: 40,
  width: 2,
  /* dialicon: ['fas fa-thermometer-half', 'fas fa-arrow-down'], */   // dial icons array when for dials have more than 1 extra info
  /* dialimage: ['volumio.png', 'air.png'],  */   // dial images array when for dials have more than 1 extra info
  showunit: true,
  shownumbers: true,
  last_update: false  // disabling last update to allow for more room
}
```
![image](https://user-images.githubusercontent.com/33834551/87257967-8b09c300-c497-11ea-9aef-0d050c829044.png)

**Type = 'Wind'** - this dial has a 360 degree range (like a compass). The wind direction can be set to point to where the wind is blowing from or to, by using the new "offset" parameter. Below I have set the dial to point to which direction the wind is blowing.

```
blocks['wind'] = {
  idx: 73,
  title: 'Wind',
  type: 'dial',
  setpoint: 18, // the entire outer ring will change color based on this setpoint, factoring in the current temperature (default 15)
  offset: 180,  // 0 will point to the wind source, 180 will point to wind direction (default is 0)
  width: 2,
  showring: true,
  showunit: true,
  shownumbers: true,
  last_update: false
}
```
![image](https://user-images.githubusercontent.com/33834551/87258034-4894b600-c498-11ea-848a-5ffc465843dd.png)

**Type = 'P1 Smart Meter'** - currently this is configured to use the "Today" counters;  CounterDelivToday and CounterToday, i.e. production vs consumption. Unlike any other dial, zero is at "12 o'clock" (instead of the tradional dial which starts at "7 o'clock"). 

```
blocks['p1'] = {
  idx: 454,
  title: 'P1 Meter',
  type: 'dial',
  width: 2,
  min: -10,
  max: 10,
  showring: true,
  showunit: true,
  shownumbers: true,
  last_update: false
}
```
P1 Smart Meter - Today's energy consumption is more than production:
![image](https://user-images.githubusercontent.com/33834551/87258096-d7093780-c498-11ea-8b78-f901b6a85447.png)

P1 Smart Meter - Today's energy production is more than consumption:
![image](https://user-images.githubusercontent.com/33834551/87258100-dd97af00-c498-11ea-9b35-8a1d529c043a.png)


**Custom styling using custom.css:**

To change the grey dial bezel color from grey to red:
```
.dt_content .dial {
    background-color: #bb2424;
}
```

To change the outer ring primary color from orange (default) to yellow:
```
.dial .bar.primary,
.dial .fill.primary {
    border-color: #d9e900;
}
```

To change the outer ring secondary color from blue (default) to lime green:
```
.dial .bar.secondary,
.dial .fill.secondary {
    border-color: #26e500;
} 
```

To change the dial needle color from orange (default) to lime green:
```
.dial-needle::before {
	border-bottom-color: lime!important;
}
```

To target just one dial, you can prefix the above code snippets with block id of the dial, for example:
```
[data-id='temp_hum_baro'] .dial-needle::before {
	border-bottom-color: lime!important;
}
```










