### PR TITLE
Corona header update

### DIFF
--- a/js/components/coronavirus.js
+++ b/js/components/coronavirus.js
@@ -280,7 +280,7 @@ function createDashGraph(me) {
 
 /* Allows user to select which header block they want */
 function addHeader(me, h) {
-  return me.block.header.includes(h) ? 'block' : 'none';
+  return me.block.header.includes(h);
 }
 
 function createReportBlock(me, province) {

--- a/js/components/coronavirus.js
+++ b/js/components/coronavirus.js
@@ -20,6 +20,7 @@ var DT_coronavirus = {
       title: 'Coronavirus',
       mode: 0,
       startDate: '22/01/2020',
+      header: [1, 2, 3, 4],
     };
     $.extend(cfg, addCfg);
     return cfg;
@@ -253,6 +254,14 @@ function createDashGraph(me) {
         ratio: stats.ratio,
         color: me.block.iconColour,
         doubling: getDoublingHours(json),
+        dailyconfirmed: confirmedGrowth,
+        dailydeaths: deathsGrowth,
+        showConfirmed: addHeader(me, 1),
+        showDeaths: addHeader(me, 2),
+        showRatio: addHeader(me, 3),
+        showDoubling: addHeader(me, 4),
+        showDailyConfirmed: addHeader(me, 5),
+        showDailyDeaths: addHeader(me, 6),
       };
 
       mountPoint
@@ -267,6 +276,11 @@ function createDashGraph(me) {
       new Chart(chartctx, graphProperties);
     });
   });
+}
+
+/* Allows user to select which header block they want */
+function addHeader(me, h) {
+  return me.block.header.includes(h) ? 'block' : 'none';
 }
 
 function createReportBlock(me, province) {

--- a/tpl/corona_graph_header.tpl
+++ b/tpl/corona_graph_header.tpl
@@ -1,9 +1,9 @@
 <span style="display:inline-flex;align-items: baseline;">
     <img src="{{flag}}.png" class="flag" style="height: 13px;">{{country}}:&nbsp; 
-    <div style="color:white;display: {{showConfirmed}};"><i class="fas fa-hospital fx" style="color:{{color}};">&nbsp;</i>{{confirmed}}&nbsp;</div>
-    <div style="color:white;display: {{showDeaths}};"><i class="fas fa-skull-crossbones fx" style="color:{{color}};">&nbsp;</i>{{deaths}}&nbsp;</div>
-    <div style="color:white;display: {{showRatio}};"><i class="fas fa-users fx" style="color:{{color}};">&nbsp;</i>{{ratio}}&nbsp;</div>
-    <div style="color:white;display: {{showDoubling}};"><i class="fas fa-angle-double-up fx" style="color:{{color}};">&nbsp;</i>{{doubling}}&nbsp;</div>
-    <div style="color:white;display: {{showDailyConfirmed}};"><i class="fas fa-user-clock" style="color:{{color}};">&nbsp;</i>{{dailyconfirmed}}&nbsp;</div>
-    <div style="color:white;display: {{showDailyDeaths}};"><i class="fas fa-user-times fx" style="color:{{color}};">&nbsp;</i>{{dailydeaths}}&nbsp;</div>
+    {{#if showConfirmed}}<div style="color:white;"><i class="fas fa-hospital fx" style="color:{{color}};">&nbsp;</i>{{confirmed}}&nbsp;</div>{{/if}}
+    {{#if showDeaths}}<div style="color:white;"><i class="fas fa-skull-crossbones fx" style="color:{{color}};">&nbsp;</i>{{deaths}}&nbsp;</div>{{/if}}
+    {{#if showRatio}}<div style="color:white;"><i class="fas fa-users fx" style="color:{{color}};">&nbsp;</i>{{ratio}}&nbsp;</div>{{/if}}
+    {{#if showDoubling}}<div style="color:white;"><i class="fas fa-angle-double-up fx" style="color:{{color}};">&nbsp;</i>{{doubling}}&nbsp;</div>{{/if}}
+    {{#if showDailyConfirmed}}<div style="color:white;"><i class="fas fa-user-clock" style="color:{{color}};">&nbsp;</i>{{dailyconfirmed}}&nbsp;</div>{{/if}}
+    {{#if showDailyDeaths}}<div style="color:white;"><i class="fas fa-user-times fx" style="color:{{color}};">&nbsp;</i>{{dailydeaths}}&nbsp;</div>{{/if}}
 </span>

--- a/tpl/corona_graph_header.tpl
+++ b/tpl/corona_graph_header.tpl
@@ -1,7 +1,9 @@
-<span>
-    <img src="{{flag}}.png" class="flag">{{country}}: <i class="fas fa-hospital fx"
-        style="color:{{color}};">&nbsp;</i>{{confirmed}}&nbsp;
-    <i class="fas fa-skull-crossbones fx" style="color:{{color}};">&nbsp;</i>{{deaths}}&nbsp;
-    <i class="fas fa-users fx" style="color:{{color}};">&nbsp;</i>{{ratio}}
-    <i class="fas fa-angle-double-up fx" style="color:{{color}};">&nbsp;</i>{{doubling}}
+<span style="display:inline-flex;align-items: baseline;">
+    <img src="{{flag}}.png" class="flag" style="height: 13px;">{{country}}:&nbsp; 
+    <div style="color:white;display: {{showConfirmed}};"><i class="fas fa-hospital fx" style="color:{{color}};">&nbsp;</i>{{confirmed}}&nbsp;</div>
+    <div style="color:white;display: {{showDeaths}};"><i class="fas fa-skull-crossbones fx" style="color:{{color}};">&nbsp;</i>{{deaths}}&nbsp;</div>
+    <div style="color:white;display: {{showRatio}};"><i class="fas fa-users fx" style="color:{{color}};">&nbsp;</i>{{ratio}}&nbsp;</div>
+    <div style="color:white;display: {{showDoubling}};"><i class="fas fa-angle-double-up fx" style="color:{{color}};">&nbsp;</i>{{doubling}}&nbsp;</div>
+    <div style="color:white;display: {{showDailyConfirmed}};"><i class="fas fa-user-clock" style="color:{{color}};">&nbsp;</i>{{dailyconfirmed}}&nbsp;</div>
+    <div style="color:white;display: {{showDailyDeaths}};"><i class="fas fa-user-times fx" style="color:{{color}};">&nbsp;</i>{{dailydeaths}}&nbsp;</div>
 </span>


### PR DESCRIPTION
Allow users to show/hide specific info within the graph headers using new "header" param on the corona block.

`header: [5, 6],    default is [1,2,3,4]`

The values correspond as follows:

1 = Total confirmed 
2 = Total deaths
3 = Ratio 
4 = Doubling 
5 = Daily confirmed
6 = Daily deaths

Below, with block set to `header: [5, 6], `

![image](https://user-images.githubusercontent.com/33834551/89228759-1d554080-d5d8-11ea-977c-a4ee53ef3ee0.png)

https://www.domoticz.com/forum/viewtopic.php?p=253811&sid=8dd9b8c1994550464f785a89a37af604#p253811

