### PR TITLE
New layout in Dial.js for wind sensor

### DIFF
--- a/js/components/dial.js
+++ b/js/components/dial.js
@@ -446,7 +446,11 @@ var DT_dial = {
    * @param {object} me  Core component object.
    */
   degrees: function (me) {
+    if(typeof me.needle !== 'undefined'){
+    var value = me.needle;
+    } else {
     var value = me.value;
+    }
     value = isDefined(me.min) && value < me.min ? me.min : value;
     value = isDefined(me.max) && value > me.max ? me.max : value;
 
@@ -848,6 +852,31 @@ var DT_dial = {
         unit: _TEMP_SYMBOL,
       }
     );
+
+//new layout of wind sensor
+if (me.block.layout == 1) {
+	me.needle = me.device.Direction;
+	me.value = me.device.Speed;
+	me.unitvalue = windUnit;
+	me.info.length = 0;
+ me.info.push({
+      icon: DT_dial.display(me.block.dialicon, 0, 3, 'fas fa-location-arrow'),
+      image: DT_dial.display(me.block.dialimage, 0, 3, false),
+      data: me.device.DirectionStr,
+      unit: '',
+    }, {
+      image: DT_dial.display(me.block.dialimage, 1, 3, false),
+      data: me.device.Direction,
+      unit: '°',
+    }, {
+      icon: DT_dial.display(me.block.dialicon, 2, 3,'fas fa-thermometer-half'),
+      image: DT_dial.display(me.block.dialimage, 0, 3, false),
+      data: me.device.Temp,
+      unit: _TEMP_SYMBOL,
+    }
+);
+
+} 
     return;
   },
 


### PR DESCRIPTION
For wind sensor I have created new layout:
- separated needle rotation from main value,
- needle rotation comes from direction,
- main value come from speed,
- direction value shifted to info.

The following needs to be added into CONFIG.js wind block definition:
```
blocks['wind_new'] = {
...
        layout: 1
...
}
```

**DEFAULT LAYOUT**
![image](https://user-images.githubusercontent.com/40031567/103438018-80520e80-4c2e-11eb-9c4c-59dec17166ae.png)

**NEW LAYOUT**
![image](https://user-images.githubusercontent.com/40031567/103438026-952ea200-4c2e-11eb-9507-a4bb15b94571.png)
