### PR TITLE
Fix Sonarr loading

### DIFF
--- a/js/components/simpleblock.js
+++ b/js/components/simpleblock.js
@@ -58,7 +58,7 @@ var DT_simpleblock = (function () {
       render: renderHorizon,
     },
     sonarr: {
-      script: 'js/sonar.js',
+      script: 'js/sonarr.js',
       render: renderSonar,
     },
     fullscreen: {


### PR DESCRIPTION
Seems there is some typo in Sonarr loading.
Dashticz load "sonar.js" instead of "sonarr.js". This fix this.
Regards,
Xavier