### PR TITLE
Small changes

### DIFF
--- a/js/components/dial.js
+++ b/js/components/dial.js
@@ -201,6 +201,7 @@ var DT_dial = (function () {
           p1smartmeter(me);
           break;
         case d.SubType === 'Text':
+        case d.SubType === 'Switch':
           text(me);
           break;
         default:
@@ -1013,7 +1014,7 @@ var DT_dial = (function () {
         res.addClass = id.addClass;
       }
       var inputType = 0;
-      if (device.SubType === 'Text') {
+      if (device.SubType === 'Text' || device.SubType === 'Switch') {
         inputType = 'text';
       }
       inputData.type = id.type || inputType;

--- a/js/components/dial.js
+++ b/js/components/dial.js
@@ -197,6 +197,7 @@ var DT_dial = (function () {
           wind(me);
           break;
         case d.Type === 'P1 Smart Meter':
+        case d.Type === 'General' && d.SubType === 'kWh':
           p1smartmeter(me);
           break;
         case d.SubType === 'Text':
@@ -1480,7 +1481,7 @@ var DT_dial = (function () {
     }
   }
   /**
-   * Configures the data for devices of P1 Smart Meter type.
+   * Configures the data for devices of P1 Smart Meter and General/kWh type.
    * @param {object} me  Core component object.
    */
   function p1smartmeter(me) {
@@ -1494,29 +1495,33 @@ var DT_dial = (function () {
     } else {
       me.min = choose(me.block.min, -10);
       me.max = choose(me.block.max, 10);
-      me.value =
-        Math.round(
-          (parseFloat(me.device.CounterDelivToday) -
-            parseFloat(me.device.CounterToday)) *
-          100
-        ) / 100;
-      me.unitvalue = 'kWh';
+      me.value = parseInt(me.device.Usage);
+      if(me.value == 0 && 'UsageDeliv' in me.device) {
+        me.value = 0-parseInt(me.device.UsageDeliv);
+      }
+      me.unitvalue = 'W';
       me.subdevice = true;
 
-      me.info.push(
-        {
-          icon: display(me.block.dialicon, 0, 2, 'fas fa-sun'),
-          image: display(me.block.dialimage, 0, 2, false),
-          data: me.device.CounterDelivToday,
-          unit: '',
-        },
-        {
-          icon: display(me.block.dialicon, 1, 2, 'fas fa-bolt'),
-          image: display(me.block.dialimage, 1, 2, false),
-          data: me.device.CounterToday,
-          unit: '',
-        }
-      );
+      if('CounterDelivToday' in me.device) {
+        me.info.push(
+          {
+            icon: display(me.block.dialicon, 0, 2, 'fas fa-sun'),
+            image: display(me.block.dialimage, 0, 2, false),
+            data: me.device.CounterDelivToday,
+            unit: '',
+          }
+        );
+      }
+      if('CounterToday' in me.device) {
+        me.info.push(
+          {
+            icon: display(me.block.dialicon, 1, 2, 'fas fa-bolt'),
+            image: display(me.block.dialimage, 1, 2, false),
+            data: me.device.CounterToday,
+            unit: '',
+          }
+        );
+      }
     }
     me.decimals = me.block.decimals;
     return;

--- a/js/components/dial.js
+++ b/js/components/dial.js
@@ -1494,8 +1494,8 @@ var DT_dial = (function () {
       me.value = parseFloat(me.device.CounterToday);
       me.unitvalue = 'm3';
     } else {
-      me.min = choose(me.block.min, -10);
-      me.max = choose(me.block.max, 10);
+      me.min = choose(me.block.min, 0);
+      me.max = choose(me.block.max, 10000);
       me.value = parseInt(me.device.Usage);
       if(me.value == 0 && 'UsageDeliv' in me.device) {
         me.value = 0-parseInt(me.device.UsageDeliv);


### PR DESCRIPTION
Hi, 2 small changes:

- Ability to display text for switches instead of raw value, used to display door status in my case:
Before:
![image](https://user-images.githubusercontent.com/3027018/214686567-6d529619-13bc-4c8f-a817-d1602eaa20e0.png)
After:
![image](https://user-images.githubusercontent.com/3027018/214687043-f2ba0d9e-cb32-47df-8f5a-e11fc7330abd.png)

- Display power instead of usage for P1 smart meter, and support for General/kWh:
Before:
![image](https://user-images.githubusercontent.com/3027018/214688885-c3282a73-ef2d-4b25-b813-e4346375fd43.png)
After:
![image](https://user-images.githubusercontent.com/3027018/214688673-26c79358-04d7-4ba0-a07a-aec3a321e7b7.png)
