### PR TITLE
Add support for HTTP Basic auth

### DIFF
--- a/js/dashticz.js
+++ b/js/dashticz.js
@@ -71,6 +71,7 @@ var Dashticz = (function () {
           plan: settings['room_plan'],
           usrEnc: usrEnc,
           pwdEnc: pwdEnc,
+          basicAuthEnc: basicAuthEnc,
           enable_websocket: settings['enable_websocket'],
           domoticz_refresh: settings['domoticz_refresh'],
           refresh_method: settings['refresh_method'],

--- a/js/domoticz-api.js
+++ b/js/domoticz-api.js
@@ -82,6 +82,7 @@ var Domoticz = (function () {
             url: cfg.url + 'json.htm?' + domoticzQuery(query),
             type: 'GET',
             async: true,
+            beforeSend: function(xhr) { if(cfg.basicAuthEnc && cfg.basicAuthEnc.length) { xhr.setRequestHeader("Authorization", "Basic " + cfg.basicAuthEnc) } },
             contentType: 'application/json',
             error: function (jqXHR, textStatus) {
               if (typeof textStatus !== 'undefined' && textStatus === 'abort') {
@@ -143,7 +144,7 @@ var Domoticz = (function () {
       }
       cfg = initcfg;
       if (cfg.url.charAt(cfg.url.length - 1) !== '/') cfg.url += '/';
-      if (cfg.usrEnc && cfg.usrEnc.length)
+      if (cfg.usrEnc && cfg.usrEnc.length && !(cfg.basicAuthEnc && cfg.basicAuthEnc.length))
         usrinfo = 'username=' + cfg.usrEnc + '&password=' + cfg.pwdEnc + '&';
       initPromise = checkWSSupport()
         .catch(function () {

--- a/js/main.js
+++ b/js/main.js
@@ -308,9 +308,9 @@ function loadFiles(dashtype) {
         pwdEnc = '';
         basicAuthEnc = ''
         if (typeof settings['user_name'] !== 'undefined') {
-          if(typeof settings['auth_mode'] !== 'undefined' && settings['auth_mode'] == 'basic') {
+          if(domoVersion.basicAuthRequired) {
             basicAuthEnc = window.btoa(settings['user_name'] + ':' + settings['pass_word']);
-          } else if(typeof settings['auth_mode'] === 'undefined' || settings['auth_mode'] == 'url') {
+          } else {
             usrEnc = window.btoa(settings['user_name']);
             pwdEnc = window.btoa(settings['pass_word']);
           }

--- a/js/main.js
+++ b/js/main.js
@@ -306,9 +306,14 @@ function loadFiles(dashtype) {
 
         usrEnc = '';
         pwdEnc = '';
+        basicAuthEnc = ''
         if (typeof settings['user_name'] !== 'undefined') {
-          usrEnc = window.btoa(settings['user_name']);
-          pwdEnc = window.btoa(settings['pass_word']);
+          if(typeof settings['auth_mode'] !== 'undefined' && settings['auth_mode'] == 'basic') {
+            basicAuthEnc = window.btoa(settings['user_name'] + ':' + settings['pass_word']);
+          } else if(typeof settings['auth_mode'] === 'undefined' || settings['auth_mode'] == 'url') {
+            usrEnc = window.btoa(settings['user_name']);
+            pwdEnc = window.btoa(settings['pass_word']);
+          }
         }
 
         checkCfgSettings();

--- a/js/version.js
+++ b/js/version.js
@@ -134,12 +134,16 @@ function setDomoBehavior() {
     },
     levelNamesEncoded: {
       version: 3.9476
+    },
+    basicAuthRequired: {
+      version: 2022.2,
+      build: 14078
     }
   }
   
   Object.keys(domoChanges).forEach(function(key) {
     var testVersion = 0 || domoChanges[key].version;
-    var testBuild = 0 || domoChanges[key].version;
+    var testBuild = 0 || domoChanges[key].build;
     var applicable = (domoVersion.version> testVersion) || ((domoVersion.version == testVersion) && (domoVersion.build>=testBuild));
     domoVersion[key] = applicable; 
   });    


### PR DESCRIPTION
There was a change recently in Domoticz auth, now giving username/password in the URL is not working anymore. HTTP Basic auth may still be used if enable in Domoticz configuration.

This PR adds the possibility to use HTTP Basic auth by adding a new settings ```auth_mode```:
```php
config['auth_mode'] = 'basic'; // use HTTP Basic auth
config['auth_mode'] = 'url';   // set username/password encoded in the URL (default if not set)
```

