### PR TITLE
Update basicdashboard.rst

### DIFF
--- a/docs/gettingstarted/basicdashboard.rst
+++ b/docs/gettingstarted/basicdashboard.rst
@@ -190,7 +190,7 @@ Example of Domoticz settings:
 
 .. image :: apiprotection2.jpg
 
-.. _oauth2::
+.. _oauth2 :
 
 Advanced method
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Warning removed: /home/pi/dashticz/docs/gettingstarted/basicdashboard.rst:193: WARNING: malformed hyperlink target.