### PR TITLE
Fix thermostat: rename to tempcontrol.js to avoid ad blockers

### DIFF
--- a/docs/develop/design.rst
+++ b/docs/develop/design.rst
@@ -17,7 +17,7 @@ Blocks
 blocks.js is responsible for creating all blocks on the Dashboard. Depending on the block type this responsibility is delegated to helpers.
 
 Switches are handled by switches.js
-Thermostats and EvoHome devices are handled by thermostat.js
+Thermostats and EvoHome devices are handled by tempcontrol.js
 
 Several specific Domoticz devices are handled by block.js itself, like P1 smart meter and  TempHumBar devices.
 

--- a/js/main.js
+++ b/js/main.js
@@ -211,7 +211,7 @@ function configureDashticz() {
 
   return $.when(
     DT_function.loadDTScript('js/switches.js'),
-    DT_function.loadDTScript('js/thermostat.js'),
+    DT_function.loadDTScript('js/tempcontrol.js'),
     DT_function.loadDTScript('js/dashticz.js'),
     DT_function.loadDTScript('js/blocks.js'),    
     DT_function.loadDTScript('js/login.js'),

--- a/js/tempcontrol.js
+++ b/js/tempcontrol.js
@@ -407,4 +407,4 @@ function switchEvoHotWater(block, state, override) {
     dial ? DT_dial.make(block) : getEvohomeHotWaterBlock(block);
   });
 }
-//# sourceURL=js/thermostat.js
+//# sourceURL=js/tempcontrol.js


### PR DESCRIPTION
Thermostat functionality was being blocked by ad blockers due to the filename. Renamed thermostat.js to tempcontrol.js to fix this issue. The +/- buttons now work correctly.