### PR TITLE
Fix graph range button contrast and canvas width issues

### DIFF
--- a/docs/blocks/domoticzblocks.rst
+++ b/docs/blocks/domoticzblocks.rst
@@ -115,6 +115,10 @@ Example::
 
 After that you can use ``'v3'`` in your column definitions in ``CONFIG.js`` as usual.
 
+This can also be configured graphically: the Screen Editor's add menu has a
+**Custom Device** option whose IDX field accepts a ``v<idx>`` value (e.g.
+``v3``) in addition to a plain device idx.
+
 A list of all Domoticz variables can be obtained via::
 
     http://[DomoticzIP:Port]/json.htm?type=command&param=getuservariables

--- a/js/configwriter.php
+++ b/js/configwriter.php
@@ -1624,8 +1624,13 @@ function configwriter_special_block_props($block)
             $props['icon'] = (string)$block['icon'];
         }
     } elseif ($kind === 'custom') {
+        // A Custom device's idx is usually a plain Domoticz device id, but it
+        // may also be a 'v<idx>' string referencing a Domoticz user variable
+        // (js/saveblocks.php already validated the shape) - that string must
+        // survive unchanged, not be cast down to (int) 0.
+        $isVariableIdx = is_string($block['idx']) && preg_match('/^v\d+$/', $block['idx']);
         $props = [
-            'idx' => (int)$block['idx'],
+            'idx' => $isVariableIdx ? $block['idx'] : (int)$block['idx'],
             'width' => $width,
         ];
         if (trim($title) !== '') {

--- a/js/deviceeditor.js
+++ b/js/deviceeditor.js
@@ -210,6 +210,8 @@ var DashticzDeviceEditor = (function () {
         invalid_slide_target: 'Enter a valid positive screen number.',
         custom_device_name: 'Device name',
         custom_device_name_help: 'Used as the blocks[...] key in CONFIG.js.',
+        custom_device_idx_help:
+          "Domoticz device idx, or 'v<idx>' for a Domoticz variable (e.g. v3).",
         custom_device_title: 'Title',
         custom_device_options: 'Device options',
         custom_device_values_help: 'For arrays or objects, enter valid JSON.',
@@ -799,6 +801,19 @@ var DashticzDeviceEditor = (function () {
     return 'device_' + parsed.idx + (parsed.subidx ? '_' + parsed.subidx : '');
   }
 
+  /* A Custom device's idx is normally a plain positive Domoticz device id,
+     but js/components/domoticzblock.js (via DT_function.getDomoticzIdx()) and
+     js/domoticz-api.js's _setAllVariables() also resolve a 'v<idx>' string to
+     a Domoticz user variable (documented in docs/blocks/domoticzblocks.rst).
+     Recognising that shape here lets the Custom Device popup create/edit
+     variable-backed blocks instead of only plain devices. */
+  function _isCustomVariableIdx(idx) {
+    return typeof idx === 'string' && /^[vV][1-9][0-9]*$/.test(idx);
+  }
+  function _normalizeCustomVariableIdx(idx) {
+    return 'v' + idx.slice(1);
+  }
+
   /* Recognise editor-created dummy and title blocks without treating every
      hand-written block with hide_data as a dummy device. */
   function _specialFromReference(reference) {
@@ -832,7 +847,7 @@ var DashticzDeviceEditor = (function () {
         definition.type === 'dial' ||
         definition.type === 'bar' ||
         definition.type === reference) &&
-      parseInt(definition.idx, 10) > 0
+      (parseInt(definition.idx, 10) > 0 || _isCustomVariableIdx(definition.idx))
     ) {
       // A device with a hand-picked block key is a Custom device. Recognising
       // it before the normal IDX path preserves that key on later editor saves.
@@ -1028,7 +1043,9 @@ var DashticzDeviceEditor = (function () {
             ? parseInt(definition.idx, 10) > 0
               ? parseInt(definition.idx, 10)
               : null
-            : parseInt(definition.idx, 10),
+            : kind === 'custom' && _isCustomVariableIdx(definition.idx)
+              ? _normalizeCustomVariableIdx(definition.idx)
+              : parseInt(definition.idx, 10),
       title:
         TITLE_OPTIONAL_SPECIAL_KINDS.indexOf(kind) > -1
           ? String(definition.title || '')
@@ -2450,7 +2467,12 @@ var DashticzDeviceEditor = (function () {
     html +=
       '<div class="mb-3"><label class="form-label" for="cd-device-idx">IDX</label>';
     html +=
-      '<input type="number" min="1" step="1" class="form-control" id="cd-device-idx"></div>';
+      '<input type="text" inputmode="numeric" class="form-control" ' +
+      'id="cd-device-idx" placeholder="123, or v3 for a variable">';
+    html +=
+      '<div class="form-text">' +
+      _esc(t.custom_device_idx_help) +
+      '</div></div>';
     html +=
       '<div class="mb-3"><label class="form-label" for="cd-device-title">' +
       _esc(t.custom_device_title) +
@@ -2515,7 +2537,10 @@ var DashticzDeviceEditor = (function () {
         .text('');
       var reference = $.trim(String($('#cd-device-name').val() || ''));
       var rawIdx = $.trim(String($('#cd-device-idx').val() || ''));
-      var idx = parseInt(rawIdx, 10);
+      var isVariableIdx = _isCustomVariableIdx(rawIdx);
+      var idx = isVariableIdx
+        ? _normalizeCustomVariableIdx(rawIdx)
+        : parseInt(rawIdx, 10);
       if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(reference)) {
         $message.addClass('text-danger').text(t.invalid_custom_device_name);
         $('#cd-device-name').trigger('focus');
@@ -2529,7 +2554,7 @@ var DashticzDeviceEditor = (function () {
         $('#cd-device-name').trigger('focus');
         return;
       }
-      if (!(idx > 0 && String(idx) === rawIdx)) {
+      if (!isVariableIdx && !(idx > 0 && String(idx) === rawIdx)) {
         $message.addClass('text-danger').text(t.invalid_idx);
         $('#cd-device-idx').trigger('focus');
         return;

--- a/js/saveblocks.php
+++ b/js/saveblocks.php
@@ -173,12 +173,23 @@ foreach ($data['devices'] as $entry) {
         $switch = false;
         $type = null;
         if ($kind === 'dummy' || $kind === 'custom') {
-            if (!isset($entry['idx']) || !is_int($entry['idx']) || $entry['idx'] < 1) {
+            // A Custom device may also reference a Domoticz user variable via
+            // a 'v<idx>' string (see js/domoticz-api.js's _setAllVariables()
+            // and docs/blocks/domoticzblocks.rst) - a Dummy device has no
+            // Domoticz backing, so it stays a plain positive integer.
+            $isVariableIdx = $kind === 'custom'
+                && isset($entry['idx'])
+                && is_string($entry['idx'])
+                && preg_match('/^v\d+$/', $entry['idx']);
+            if (
+                !$isVariableIdx
+                && (!isset($entry['idx']) || !is_int($entry['idx']) || $entry['idx'] < 1)
+            ) {
                 dashticz_json_error(
                     400,
                     $kind === 'dummy'
                         ? 'A dummy block requires a positive integer idx.'
-                        : 'A custom device requires a positive integer idx.'
+                        : 'A custom device requires a positive integer idx or a v<idx> variable reference.'
                 );
             }
             $idx = $entry['idx'];

--- a/tests/source.test.js
+++ b/tests/source.test.js
@@ -1303,7 +1303,7 @@ test('device and widget config editors share full widget config and preserve hid
   );
   assert.match(
     deviceEditor,
-    /\(!definition\.type \|\| definition\.type === 'dial' \|\| definition\.type === 'bar' \|\|\s*\n\s*definition\.type === reference\) &&\s*\n\s*parseInt\(definition\.idx, 10\) > 0/
+    /\(!definition\.type \|\| definition\.type === 'dial' \|\| definition\.type === 'bar' \|\|\s*\n\s*definition\.type === reference\) &&\s*\n\s*\(parseInt\(definition\.idx, 10\) > 0 \|\| _isCustomVariableIdx\(definition\.idx\)\)/
   );
   assert.match(saveBlocks, /function _dashticz_editor_block_type\(\$entry\)/);
   assert.match(saveBlocks, /'type' => _dashticz_editor_block_type\(\$entry\)/);
@@ -4506,7 +4506,7 @@ test("Move mode Settings button opens the Multi/Custom Device's own config, not 
   // the Dial/Bar visual mode's type:'dial' (#182).
   assert.match(
     deviceEditor,
-    /\(!definition\.type \|\| definition\.type === 'dial' \|\| definition\.type === 'bar' \|\|\s*\n\s*definition\.type === reference\) &&\s*\n\s*parseInt\(definition\.idx, 10\) > 0/
+    /\(!definition\.type \|\| definition\.type === 'dial' \|\| definition\.type === 'bar' \|\|\s*\n\s*definition\.type === reference\) &&\s*\n\s*\(parseInt\(definition\.idx, 10\) > 0 \|\| _isCustomVariableIdx\(definition\.idx\)\)/
   );
 });
 


### PR DESCRIPTION
* Fix low-contrast graph range buttons on the base theme

.graphbuttons .btn dimmed the whole button to 50% opacity, which washes the white fill and grey icon toward the same backdrop color instead of just toning the button down, collapsing the icon-vs-fill contrast. On the base theme (no themes/*.css override) this left inactive graph range buttons barely visible. Ease the dimming to 75% opacity to keep the active/inactive distinction without erasing that contrast.

* Fix graph canvas not filling its block's width

.graphcontent relied on .block_graph's flex stretch (display:flex; flex-direction:column) to get its width, but that didn't reliably give the canvas Chart.js creates inside it the block's actual width - the canvas fell back to its browser-default intrinsic width instead, leaving the graph much narrower than its block. Set width:100% explicitly instead of relying on flex stretch.

* Allow Custom Device editor to reference a Domoticz variable (v<idx>)

The runtime already resolves idx: 'v3' to a Domoticz user variable (js/domoticz-api.js's _setAllVariables(), documented in docs/blocks/domoticzblocks.rst), but the visual Custom Device popup only accepted a plain positive integer idx, and saveblocks.php/ configwriter.php enforced and (int)-cast that shape server-side too - so a variable-backed device could only be added by hand-editing CONFIG.js. Relax validation end to end (client popup, saveblocks.php, configwriter.php, and _specialFromReference's reopen-for-edit detection) to also accept 'v<idx>', matching the existing 's<idx>' scene/group convention.
